### PR TITLE
feat: add shared Region of Interest (ROI) cropping for text recognition and barcode scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ const frameOutput = useFrameOutput({
 - `language?: 'LATIN' | 'CHINESE' | 'DEVANAGARI' | 'JAPANESE' | 'KOREAN'`
 - `scaleFactor?: number` (0.9-1.0)
 - `invertColors?: boolean`
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the frame; see [Region of Interest](#region-of-interest))
 - `frameProcessInterval?: number` (deprecated, throttle frames manually inside `onFrame` instead)
 
 `TextRecognitionArguments`:
@@ -191,6 +192,7 @@ console.log(result.blocks);
 - `language?: 'LATIN' | 'CHINESE' | 'DEVANAGARI' | 'JAPANESE' | 'KOREAN'`
 - `orientation?: 'portrait' | 'portrait-upside-down' | 'landscape-left' | 'landscape-right'`
 - `invertColors?: boolean`
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the image; see [Region of Interest](#region-of-interest))
 
 > The native bridge normalizes URIs (`file://` is removed on iOS and added on Android if missing). Supported formats: JPEG, PNG, WebP.
 
@@ -252,6 +254,7 @@ const frameOutput = useFrameOutput({
 - `enableAllPotentialBarcodes?: boolean` (Android only)
 - `scaleFactor?: number` (0.9-1.0)
 - `invertColors?: boolean`
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the frame; see [Region of Interest](#region-of-interest))
 - `frameProcessInterval?: number` (deprecated, throttle frames manually inside `onFrame` instead)
 
 Supported `formats` values:
@@ -305,6 +308,7 @@ for (const barcode of result.barcodes) {
 - `orientation?: 'portrait' | 'portrait-upside-down' | 'landscape-left' | 'landscape-right'`
 - `invertColors?: boolean`
 - `scaleFactor?: number` (0.9-1.0)
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the image; see [Region of Interest](#region-of-interest))
 
 `BarcodeScanningResult` includes:
 
@@ -347,6 +351,29 @@ import {
 } from 'react-native-vision-camera-mlkit';
 
 assertFeatureAvailable(MLKIT_FEATURE_KEYS.TEXT_RECOGNITION);
+```
+
+### Region of Interest
+
+Every feature accepts an optional `roi` to crop processing to a rectangle of the frame/image before running ML Kit, reducing CPU/GPU work. Result coordinates (bounding boxes, corners) are always mapped back to full source coordinates, so overlays don't need to account for the crop.
+
+```ts
+type RegionOfInterest = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** @default 'normalized' */
+  unit?: 'normalized' | 'pixel';
+};
+```
+
+By default `x`/`y`/`width`/`height` are normalized to the `0..1` range relative to the source frame/image (so `x + width` and `y + height` must each be `<= 1`); set `unit: 'pixel'` to use absolute pixel values instead.
+
+```ts
+const { textRecognition } = useTextRecognition({
+  roi: { x: 0.25, y: 0.25, width: 0.5, height: 0.5 },
+});
 ```
 
 ## Performance

--- a/android/src/main/java/com/margelo/nitro/visioncameramlkit/BarcodeScannerOptions+toDomain.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameramlkit/BarcodeScannerOptions+toDomain.kt
@@ -15,4 +15,5 @@ internal fun BarcodeScannerOptions.toImagePreprocessingOptions(): ImagePreproces
   ImagePreprocessingOptions(
     invertColors = invertColors ?: false,
     scaleFactor = scaleFactor?.toFloat() ?: 1.0f,
+    roi = roi.toDomainRegionOfInterest(),
   )

--- a/android/src/main/java/com/margelo/nitro/visioncameramlkit/HybridBarcodeScanner.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameramlkit/HybridBarcodeScanner.kt
@@ -3,6 +3,7 @@ package com.margelo.nitro.visioncameramlkit
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.camera.HybridFrameSpec
+import com.visioncameramlkit.domain.models.remap
 import com.visioncameramlkit.infrastructure.image.ImagePreprocessor
 import com.visioncameramlkit.infrastructure.mlkit.factories.BarcodeScanningServiceFactory
 
@@ -16,8 +17,12 @@ class HybridBarcodeScanner(
   private val imageOptions = options.toImagePreprocessingOptions()
   private val recognitionService = BarcodeScanningServiceFactory.create(barcodeOptions)
 
-  override fun recognize(frame: HybridFrameSpec, args: MLKitBaseArguments?): BarcodeScannerResult {
+  override fun recognize(
+    frame: HybridFrameSpec,
+    args: MLKitBaseArguments?,
+  ): BarcodeScannerResult {
     val processedImage = frame.toProcessedImage(imagePreprocessor, imageOptions)
-    return recognitionService.recognize(processedImage).toNitroResult()
+    val result = recognitionService.recognize(processedImage)
+    return result.remap(processedImage.metadata).toNitroResult()
   }
 }

--- a/android/src/main/java/com/margelo/nitro/visioncameramlkit/HybridFrameSpec+toProcessedImage.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameramlkit/HybridFrameSpec+toProcessedImage.kt
@@ -31,7 +31,8 @@ internal fun ImagePreprocessor.preprocessFrame(
   val needsBitmapProcessing =
     options.invertColors ||
       effectiveScale < 1.0f ||
-      frame.isMirrored
+      frame.isMirrored ||
+      options.roi != null
 
   if (!needsBitmapProcessing) {
     val mediaImage =
@@ -52,15 +53,17 @@ internal fun ImagePreprocessor.preprocessFrame(
   }
 
   val orientedBitmap = image.toBitmap(frame.orientation, frame.isMirrored)
+  val (croppedBitmap, cropRect) = cropToRegionOfInterest(orientedBitmap, options.roi)
+
   val scaledBitmap =
     if (effectiveScale < 1.0f) {
-      orientedBitmap.scale(
-        (orientedBitmap.width * effectiveScale).toInt(),
-        (orientedBitmap.height * effectiveScale).toInt(),
+      croppedBitmap.scale(
+        (croppedBitmap.width * effectiveScale).toInt(),
+        (croppedBitmap.height * effectiveScale).toInt(),
         false,
       )
     } else {
-      orientedBitmap
+      croppedBitmap
     }
 
   val processedBitmap =
@@ -78,6 +81,9 @@ internal fun ImagePreprocessor.preprocessFrame(
         height = processedBitmap.height,
         rotation = 0,
         isInverted = options.invertColors,
+        offsetX = cropRect.left,
+        offsetY = cropRect.top,
+        scaleFactor = effectiveScale,
       ),
   )
 }

--- a/android/src/main/java/com/margelo/nitro/visioncameramlkit/HybridTextRecognizer.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameramlkit/HybridTextRecognizer.kt
@@ -3,6 +3,7 @@ package com.margelo.nitro.visioncameramlkit
 import androidx.annotation.Keep
 import com.facebook.proguard.annotations.DoNotStrip
 import com.margelo.nitro.camera.HybridFrameSpec
+import com.visioncameramlkit.domain.models.remap
 import com.visioncameramlkit.infrastructure.image.ImagePreprocessor
 import com.visioncameramlkit.infrastructure.mlkit.factories.TextRecognitionServiceFactory
 
@@ -16,8 +17,12 @@ class HybridTextRecognizer(
   private val imageOptions = options.toImagePreprocessingOptions()
   private val recognitionService = TextRecognitionServiceFactory.create(textOptions.language)
 
-  override fun recognize(frame: HybridFrameSpec, args: MLKitBaseArguments?): TextRecognitionResult {
+  override fun recognize(
+    frame: HybridFrameSpec,
+    args: MLKitBaseArguments?,
+  ): TextRecognitionResult {
     val processedImage = frame.toProcessedImage(imagePreprocessor, imageOptions)
-    return recognitionService.recognize(processedImage).toNitroResult()
+    val result = recognitionService.recognize(processedImage)
+    return result.remap(processedImage.metadata).toNitroResult()
   }
 }

--- a/android/src/main/java/com/margelo/nitro/visioncameramlkit/RegionOfInterest+toDomain.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameramlkit/RegionOfInterest+toDomain.kt
@@ -1,0 +1,21 @@
+package com.margelo.nitro.visioncameramlkit
+
+internal fun RegionOfInterest?.toDomainRegionOfInterest(): com.visioncameramlkit.domain.models.RegionOfInterest? =
+  this?.let {
+    com.visioncameramlkit.domain.models.RegionOfInterest(
+      x = it.x.toFloat(),
+      y = it.y.toFloat(),
+      width = it.width.toFloat(),
+      height = it.height.toFloat(),
+      unit = it.unit.toDomainRegionOfInterestUnit(),
+    )
+  }
+
+private fun RegionOfInterestUnit?.toDomainRegionOfInterestUnit(): com.visioncameramlkit.domain.models.RegionOfInterestUnit =
+  when (this) {
+    RegionOfInterestUnit.PIXEL -> com.visioncameramlkit.domain.models.RegionOfInterestUnit.PIXEL
+
+    RegionOfInterestUnit.NORMALIZED,
+    null,
+    -> com.visioncameramlkit.domain.models.RegionOfInterestUnit.NORMALIZED
+  }

--- a/android/src/main/java/com/margelo/nitro/visioncameramlkit/TextRecognizerOptions+toDomain.kt
+++ b/android/src/main/java/com/margelo/nitro/visioncameramlkit/TextRecognizerOptions+toDomain.kt
@@ -14,4 +14,5 @@ internal fun TextRecognizerOptions.toImagePreprocessingOptions(): ImagePreproces
   ImagePreprocessingOptions(
     invertColors = invertColors ?: false,
     scaleFactor = scaleFactor?.toFloat() ?: 1.0f,
+    roi = roi.toDomainRegionOfInterest(),
   )

--- a/android/src/main/java/com/visioncameramlkit/application/usecases/RecognizeBarcodesUseCase.kt
+++ b/android/src/main/java/com/visioncameramlkit/application/usecases/RecognizeBarcodesUseCase.kt
@@ -3,6 +3,7 @@ package com.visioncameramlkit.application.usecases
 import com.visioncameramlkit.domain.models.BarcodeScanningOptions
 import com.visioncameramlkit.domain.models.BarcodeScanningResult
 import com.visioncameramlkit.domain.models.ImagePreprocessingOptions
+import com.visioncameramlkit.domain.models.remap
 import com.visioncameramlkit.domain.services.IImagePreprocessor
 import com.visioncameramlkit.domain.services.IRecognitionService
 import java.io.File
@@ -21,9 +22,11 @@ class RecognizeBarcodesUseCase(
         invertColors = imageOptions.invertColors,
         orientation = imageOptions.orientation,
         scaleFactor = imageOptions.scaleFactor,
+        roi = imageOptions.roi,
       )
 
     val processedImage = imagePreprocessor.preprocessImage(imageFile, preprocessingOptions)
-    return recognitionService.recognize(processedImage)
+    val result = recognitionService.recognize(processedImage)
+    return result.remap(processedImage.metadata)
   }
 }

--- a/android/src/main/java/com/visioncameramlkit/application/usecases/RecognizeTextUseCase.kt
+++ b/android/src/main/java/com/visioncameramlkit/application/usecases/RecognizeTextUseCase.kt
@@ -3,6 +3,7 @@ package com.visioncameramlkit.application.usecases
 import com.visioncameramlkit.domain.models.ImagePreprocessingOptions
 import com.visioncameramlkit.domain.models.TextRecognitionOptions
 import com.visioncameramlkit.domain.models.TextRecognitionResult
+import com.visioncameramlkit.domain.models.remap
 import com.visioncameramlkit.domain.services.IImagePreprocessor
 import com.visioncameramlkit.domain.services.IRecognitionService
 import java.io.File
@@ -21,9 +22,11 @@ class RecognizeTextUseCase(
         invertColors = imageOptions.invertColors,
         orientation = imageOptions.orientation,
         scaleFactor = imageOptions.scaleFactor,
+        roi = imageOptions.roi,
       )
 
     val processedImage = imagePreprocessor.preprocessImage(imageFile, preprocessingOptions)
-    return recognitionService.recognize(processedImage)
+    val result = recognitionService.recognize(processedImage)
+    return result.remap(processedImage.metadata)
   }
 }

--- a/android/src/main/java/com/visioncameramlkit/bridge/handlers/StaticBarcodeScanningHandler.kt
+++ b/android/src/main/java/com/visioncameramlkit/bridge/handlers/StaticBarcodeScanningHandler.kt
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.visioncameramlkit.application.usecases.RecognizeBarcodesUseCase
 import com.visioncameramlkit.bridge.parsers.BarcodeScanningOptionParser
+import com.visioncameramlkit.bridge.parsers.RegionOfInterestOptionParser
 import com.visioncameramlkit.domain.models.BarcodeScanningOptions
 import com.visioncameramlkit.domain.models.ImagePreprocessingOptions
 import com.visioncameramlkit.domain.models.Orientation
@@ -127,6 +128,7 @@ class StaticBarcodeScanningHandler(
       invertColors = options.getOrDefault("invertColors", false),
       orientation = options.getString("orientation")?.let { parseOrientation(it) },
       scaleFactor = options.getOrDefault("scaleFactor", 1.0f),
+      roi = RegionOfInterestOptionParser.parse(options),
     )
 
   private fun parseBarcodeOptions(options: ReadableMap): BarcodeScanningOptions =

--- a/android/src/main/java/com/visioncameramlkit/bridge/handlers/StaticTextRecognitionHandler.kt
+++ b/android/src/main/java/com/visioncameramlkit/bridge/handlers/StaticTextRecognitionHandler.kt
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.visioncameramlkit.application.usecases.RecognizeTextUseCase
+import com.visioncameramlkit.bridge.parsers.RegionOfInterestOptionParser
 import com.visioncameramlkit.domain.models.ImagePreprocessingOptions
 import com.visioncameramlkit.domain.models.Orientation
 import com.visioncameramlkit.domain.models.TextRecognitionLanguage
@@ -134,6 +135,7 @@ class StaticTextRecognitionHandler(
     ImagePreprocessingOptions(
       invertColors = options.getBoolean("invertColors"),
       orientation = options.getString("orientation")?.let { parseOrientation(it) },
+      roi = RegionOfInterestOptionParser.parse(options),
     )
 
   private fun parseOrientation(orientation: String): Orientation? =

--- a/android/src/main/java/com/visioncameramlkit/bridge/parsers/RegionOfInterestOptionParser.kt
+++ b/android/src/main/java/com/visioncameramlkit/bridge/parsers/RegionOfInterestOptionParser.kt
@@ -1,0 +1,32 @@
+package com.visioncameramlkit.bridge.parsers
+
+import com.facebook.react.bridge.ReadableMap
+import com.visioncameramlkit.domain.models.RegionOfInterest
+import com.visioncameramlkit.domain.models.RegionOfInterestUnit
+
+object RegionOfInterestOptionParser {
+  /**
+   * Parses an optional `roi` key from [readableMap] into a domain [RegionOfInterest].
+   * Returns `null` when the key is absent, matching the "no ROI" default.
+   */
+  fun parse(readableMap: ReadableMap): RegionOfInterest? {
+    if (!readableMap.hasKey("roi") || readableMap.isNull("roi")) {
+      return null
+    }
+    val roiMap = readableMap.getMap("roi") ?: return null
+
+    return RegionOfInterest(
+      x = roiMap.getDouble("x").toFloat(),
+      y = roiMap.getDouble("y").toFloat(),
+      width = roiMap.getDouble("width").toFloat(),
+      height = roiMap.getDouble("height").toFloat(),
+      unit = parseUnit(roiMap.getString("unit")),
+    )
+  }
+
+  private fun parseUnit(unit: String?): RegionOfInterestUnit =
+    when (unit) {
+      "pixel" -> RegionOfInterestUnit.PIXEL
+      else -> RegionOfInterestUnit.NORMALIZED
+    }
+}

--- a/android/src/main/java/com/visioncameramlkit/domain/models/BarcodeScanningResult+remap.kt
+++ b/android/src/main/java/com/visioncameramlkit/domain/models/BarcodeScanningResult+remap.kt
@@ -1,0 +1,14 @@
+package com.visioncameramlkit.domain.models
+
+/**
+ * Remaps every bounding box and corner in this result from processed-image coordinates
+ * back to source image/frame coordinates, using [metadata]'s crop offset and scale
+ * factor. See [BoundingBox.remap] and [Corner.remap] for the primitive.
+ */
+fun BarcodeScanningResult.remap(metadata: ImageMetadata): BarcodeScanningResult = copy(barcodes = barcodes.map { it.remap(metadata) })
+
+private fun BarcodeData.remap(metadata: ImageMetadata): BarcodeData =
+  copy(
+    bounds = bounds?.remap(metadata),
+    corners = corners?.map { it.remap(metadata) },
+  )

--- a/android/src/main/java/com/visioncameramlkit/domain/models/CoordinateRemap.kt
+++ b/android/src/main/java/com/visioncameramlkit/domain/models/CoordinateRemap.kt
@@ -1,0 +1,35 @@
+package com.visioncameramlkit.domain.models
+
+/**
+ * Translates a coordinate produced against a processed (cropped and/or scaled) image
+ * back into the original source image/frame's pixel space.
+ *
+ * Preprocessing crops first (in pre-scale pixel space), then scales. To invert that,
+ * this first undoes the scale factor (dividing by it), then adds back the crop offset,
+ * which was recorded in pre-scale pixel space: `source = offset + processed / scaleFactor`.
+ */
+private fun remapPoint(
+  value: Double,
+  offset: Int,
+  scaleFactor: Float,
+): Double = offset + value / scaleFactor
+
+fun BoundingBox.remap(metadata: ImageMetadata): BoundingBox =
+  BoundingBox(
+    x = remapPoint(x, metadata.offsetX, metadata.scaleFactor),
+    y = remapPoint(y, metadata.offsetY, metadata.scaleFactor),
+    centerX = remapPoint(centerX, metadata.offsetX, metadata.scaleFactor),
+    centerY = remapPoint(centerY, metadata.offsetY, metadata.scaleFactor),
+    width = width / metadata.scaleFactor,
+    height = height / metadata.scaleFactor,
+    top = remapPoint(top, metadata.offsetY, metadata.scaleFactor),
+    left = remapPoint(left, metadata.offsetX, metadata.scaleFactor),
+    bottom = remapPoint(bottom, metadata.offsetY, metadata.scaleFactor),
+    right = remapPoint(right, metadata.offsetX, metadata.scaleFactor),
+  )
+
+fun Corner.remap(metadata: ImageMetadata): Corner =
+  Corner(
+    x = remapPoint(x, metadata.offsetX, metadata.scaleFactor),
+    y = remapPoint(y, metadata.offsetY, metadata.scaleFactor),
+  )

--- a/android/src/main/java/com/visioncameramlkit/domain/models/ImagePreprocessingOptions.kt
+++ b/android/src/main/java/com/visioncameramlkit/domain/models/ImagePreprocessingOptions.kt
@@ -6,4 +6,5 @@ data class ImagePreprocessingOptions(
   val outputOrientation: OutputOrientation? = null,
   val scaleFactor: Float = 1.0f,
   val orientation: Orientation? = null,
+  val roi: RegionOfInterest? = null,
 )

--- a/android/src/main/java/com/visioncameramlkit/domain/models/ProcessedImage.kt
+++ b/android/src/main/java/com/visioncameramlkit/domain/models/ProcessedImage.kt
@@ -12,4 +12,11 @@ data class ImageMetadata(
   val height: Int,
   val rotation: Int,
   val isInverted: Boolean,
+  // Crop origin (in post-rotation, pre-scale pixel space) applied by an ROI, if any.
+  // Downstream result remapping adds this back onto ML Kit's result coordinates.
+  val offsetX: Int = 0,
+  val offsetY: Int = 0,
+  // Scale factor applied during preprocessing, needed to unscale result coordinates
+  // back to source image/frame pixel space.
+  val scaleFactor: Float = 1.0f,
 )

--- a/android/src/main/java/com/visioncameramlkit/domain/models/RegionOfInterest.kt
+++ b/android/src/main/java/com/visioncameramlkit/domain/models/RegionOfInterest.kt
@@ -1,0 +1,57 @@
+package com.visioncameramlkit.domain.models
+
+import android.graphics.Rect
+
+enum class RegionOfInterestUnit {
+  NORMALIZED,
+  PIXEL,
+}
+
+data class RegionOfInterest(
+  val x: Float,
+  val y: Float,
+  val width: Float,
+  val height: Float,
+  val unit: RegionOfInterestUnit = RegionOfInterestUnit.NORMALIZED,
+) {
+  init {
+    require(x >= 0 && y >= 0) {
+      "Invalid RegionOfInterest: x and y must be >= 0 (got x=$x, y=$y)."
+    }
+    require(width > 0 && height > 0) {
+      "Invalid RegionOfInterest: width and height must be > 0 (got width=$width, height=$height)."
+    }
+    if (unit == RegionOfInterestUnit.NORMALIZED) {
+      require(x + width <= 1f && y + height <= 1f) {
+        "Invalid RegionOfInterest: normalized x + width and y + height must be <= 1 " +
+          "(got x=$x, width=$width, y=$y, height=$height)."
+      }
+    }
+  }
+}
+
+/**
+ * Resolves this [RegionOfInterest] into a pixel-space [Rect] for an image of the given
+ * dimensions, clamping the result to stay within the image bounds.
+ */
+fun RegionOfInterest.resolveToPixelRect(
+  imageWidth: Int,
+  imageHeight: Int,
+): Rect {
+  val (px, py, pw, ph) =
+    when (unit) {
+      RegionOfInterestUnit.PIXEL -> {
+        listOf(x, y, width, height)
+      }
+
+      RegionOfInterestUnit.NORMALIZED -> {
+        listOf(x * imageWidth, y * imageHeight, width * imageWidth, height * imageHeight)
+      }
+    }
+
+  val left = px.toInt().coerceIn(0, imageWidth)
+  val top = py.toInt().coerceIn(0, imageHeight)
+  val right = (px + pw).toInt().coerceIn(left, imageWidth)
+  val bottom = (py + ph).toInt().coerceIn(top, imageHeight)
+  return Rect(left, top, right, bottom)
+}

--- a/android/src/main/java/com/visioncameramlkit/domain/models/TextRecognitionResult+remap.kt
+++ b/android/src/main/java/com/visioncameramlkit/domain/models/TextRecognitionResult+remap.kt
@@ -1,0 +1,35 @@
+package com.visioncameramlkit.domain.models
+
+/**
+ * Remaps every bounding box and corner in this result tree from processed-image
+ * coordinates back to source image/frame coordinates, using [metadata]'s crop offset
+ * and scale factor. See [BoundingBox.remap] and [Corner.remap] for the primitive.
+ */
+fun TextRecognitionResult.remap(metadata: ImageMetadata): TextRecognitionResult = copy(blocks = blocks.map { it.remap(metadata) })
+
+private fun TextBlock.remap(metadata: ImageMetadata): TextBlock =
+  copy(
+    bounds = bounds?.remap(metadata),
+    corners = corners?.map { it.remap(metadata) },
+    lines = lines.map { it.remap(metadata) },
+  )
+
+private fun TextLine.remap(metadata: ImageMetadata): TextLine =
+  copy(
+    bounds = bounds?.remap(metadata),
+    corners = corners?.map { it.remap(metadata) },
+    elements = elements.map { it.remap(metadata) },
+  )
+
+private fun TextElement.remap(metadata: ImageMetadata): TextElement =
+  copy(
+    bounds = bounds?.remap(metadata),
+    corners = corners?.map { it.remap(metadata) },
+    symbols = symbols.map { it.remap(metadata) },
+  )
+
+private fun TextSymbol.remap(metadata: ImageMetadata): TextSymbol =
+  copy(
+    bounds = bounds?.remap(metadata),
+    corners = corners?.map { it.remap(metadata) },
+  )

--- a/android/src/main/java/com/visioncameramlkit/infrastructure/image/ImagePreprocessor.kt
+++ b/android/src/main/java/com/visioncameramlkit/infrastructure/image/ImagePreprocessor.kt
@@ -8,6 +8,7 @@ import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.graphics.Matrix
 import android.graphics.Paint
+import android.graphics.Rect
 import androidx.core.graphics.scale
 import androidx.exifinterface.media.ExifInterface
 import com.google.mlkit.vision.common.InputImage
@@ -15,6 +16,8 @@ import com.visioncameramlkit.domain.models.ImageMetadata
 import com.visioncameramlkit.domain.models.ImagePreprocessingOptions
 import com.visioncameramlkit.domain.models.Orientation
 import com.visioncameramlkit.domain.models.ProcessedImage
+import com.visioncameramlkit.domain.models.RegionOfInterest
+import com.visioncameramlkit.domain.models.resolveToPixelRect
 import com.visioncameramlkit.domain.services.IImagePreprocessor
 import java.io.File
 
@@ -24,6 +27,23 @@ class ImagePreprocessor : IImagePreprocessor {
   private fun clampScale(scaleFactor: Float?): Float {
     val scale = scaleFactor ?: 1.0f
     return scale.coerceIn(0.9f, 1.0f)
+  }
+
+  /**
+   * Crops [bitmap] to the given [roi], if any. Returns the (possibly unchanged) bitmap
+   * alongside the pixel offset of the crop origin, so callers can remap result
+   * coordinates back to the pre-crop pixel space.
+   */
+  fun cropToRegionOfInterest(
+    bitmap: Bitmap,
+    roi: RegionOfInterest?,
+  ): Pair<Bitmap, Rect> {
+    if (roi == null) {
+      return bitmap to Rect(0, 0, bitmap.width, bitmap.height)
+    }
+    val rect = roi.resolveToPixelRect(bitmap.width, bitmap.height)
+    val croppedBitmap = createBitmap(bitmap, rect.left, rect.top, rect.width(), rect.height())
+    return croppedBitmap to rect
   }
 
   fun invertBitmap(bitmap: Bitmap): Bitmap =
@@ -82,28 +102,30 @@ class ImagePreprocessor : IImagePreprocessor {
     val rotatedBitmap = rotateBitmap(bitmap, effectiveOrientation)
     val effectiveScale = clampScale(options.scaleFactor)
 
+    val (croppedBitmap, cropRect) = cropToRegionOfInterest(rotatedBitmap, options.roi)
+
     val processedBitmap =
       if (options.invertColors) {
         val scaledBitmap =
           if (effectiveScale < 1.0f) {
-            rotatedBitmap.scale(
-              (rotatedBitmap.width * effectiveScale).toInt(),
-              (rotatedBitmap.height * effectiveScale).toInt(),
+            croppedBitmap.scale(
+              (croppedBitmap.width * effectiveScale).toInt(),
+              (croppedBitmap.height * effectiveScale).toInt(),
               false,
             )
           } else {
-            rotatedBitmap
+            croppedBitmap
           }
         invertBitmap(scaledBitmap)
       } else {
         if (effectiveScale < 1.0f) {
-          rotatedBitmap.scale(
-            (rotatedBitmap.width * effectiveScale).toInt(),
-            (rotatedBitmap.height * effectiveScale).toInt(),
+          croppedBitmap.scale(
+            (croppedBitmap.width * effectiveScale).toInt(),
+            (croppedBitmap.height * effectiveScale).toInt(),
             false,
           )
         } else {
-          rotatedBitmap
+          croppedBitmap
         }
       }
 
@@ -115,6 +137,9 @@ class ImagePreprocessor : IImagePreprocessor {
         height = processedBitmap.height,
         rotation = 0, // Static images are already oriented
         isInverted = options.invertColors,
+        offsetX = cropRect.left,
+        offsetY = cropRect.top,
+        scaleFactor = effectiveScale,
       )
 
     return ProcessedImage(inputImage, metadata)

--- a/docs/barcode-scanning.md
+++ b/docs/barcode-scanning.md
@@ -50,6 +50,7 @@ const frameOutput = useFrameOutput({
 - `enableAllPotentialBarcodes?: boolean` (Android only)
 - `scaleFactor?: number` (`0.9`-`1.0`)
 - `invertColors?: boolean`
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the frame; see the [Region of Interest](../README.md#region-of-interest) section in the main README)
 - `frameProcessInterval?: number` (deprecated; throttle frames manually inside `onFrame` instead)
 
 ### Frame arguments
@@ -77,6 +78,7 @@ const result = await processImageBarcodeScanning(imageUri, {
 - `orientation?: 'portrait' | 'portrait-upside-down' | 'landscape-left' | 'landscape-right'`
 - `invertColors?: boolean`
 - `scaleFactor?: number` (`0.9`-`1.0`)
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the image; see the [Region of Interest](../README.md#region-of-interest) section in the main README)
 
 ## Supported formats
 

--- a/docs/text-recognition.md
+++ b/docs/text-recognition.md
@@ -47,6 +47,7 @@ const frameOutput = useFrameOutput({
 - `language?: 'LATIN' | 'CHINESE' | 'DEVANAGARI' | 'JAPANESE' | 'KOREAN'`
 - `scaleFactor?: number` (`0.9`-`1.0`)
 - `invertColors?: boolean`
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the frame; see the [Region of Interest](../README.md#region-of-interest) section in the main README)
 - `frameProcessInterval?: number` (deprecated; throttle frames manually inside `onFrame` instead)
 
 ### Frame arguments
@@ -72,6 +73,7 @@ const result = await processImageTextRecognition(imageUri, {
 - `orientation?: 'portrait' | 'portrait-upside-down' | 'landscape-left' | 'landscape-right'`
 - `invertColors?: boolean`
 - `scaleFactor?: number` (`0.9`-`1.0`)
+- `roi?: RegionOfInterest` (crop processing to a rectangle of the image; see the [Region of Interest](../README.md#region-of-interest) section in the main README)
 
 ## Result shape
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2447,7 +2447,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - VisionCameraMLKit (1.0.1):
+  - VisionCameraMLKit (2.0.0):
     - GoogleMLKit/BarcodeScanning
     - GoogleMLKit/TextRecognition
     - GoogleMLKit/TextRecognitionChinese
@@ -2908,7 +2908,7 @@ SPEC CHECKSUMS:
   RNSVG: 6cae8d4082913be2eb43eaec2a456222c42195ed
   RNWorklets: 53439575fed8525fb8d1cabcc05a3d4d91e6ffe4
   VisionCamera: 2d364657571d6b6404830269d05b1de244586a40
-  VisionCameraMLKit: fa9794aa8b135e32be2d6aeacc22bc07b0b34d82
+  VisionCameraMLKit: fe1db106ab49d735ac1972c0af27c06778ef8c7e
   VisionCameraWorklets: 8393549fac54f37a4cf6a7b1088688cf9b309b7f
   Yoga: 94172d87dd5d83fc929bf1ee53121b5d4490b5f2
 

--- a/example/src/components/ui/RegionOfInterestControl.tsx
+++ b/example/src/components/ui/RegionOfInterestControl.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import type { RegionOfInterest } from 'react-native-vision-camera-mlkit';
+import { SectionSlider } from './SectionSlider';
+import { SectionSwitch } from './SectionSwitch';
+
+type NormalizedRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type RegionOfInterestControlProps = {
+  value: RegionOfInterest | undefined;
+  onValueChange: (roi: RegionOfInterest | undefined) => void;
+};
+
+const DEFAULT_RECT: NormalizedRect = {
+  x: 0.25,
+  y: 0.25,
+  width: 0.5,
+  height: 0.5,
+};
+
+const RegionOfInterestControl = ({
+  value,
+  onValueChange,
+}: RegionOfInterestControlProps) => {
+  const [rect, setRect] = useState<NormalizedRect>(() => ({
+    x: value?.x ?? DEFAULT_RECT.x,
+    y: value?.y ?? DEFAULT_RECT.y,
+    width: value?.width ?? DEFAULT_RECT.width,
+    height: value?.height ?? DEFAULT_RECT.height,
+  }));
+
+  const enabled = value !== undefined;
+
+  const updateRect = (patch: Partial<NormalizedRect>) => {
+    const next = { ...rect, ...patch };
+    const clamped: NormalizedRect = {
+      x: Math.min(next.x, 1 - next.width),
+      y: Math.min(next.y, 1 - next.height),
+      width: next.width,
+      height: next.height,
+    };
+
+    setRect(clamped);
+    if (enabled) {
+      onValueChange({ ...clamped, unit: 'normalized' });
+    }
+  };
+
+  return (
+    <>
+      <SectionSwitch
+        label="Enable Region of Interest"
+        description="Crop ML Kit processing to a rectangle of the frame/image to reduce CPU/GPU work."
+        value={enabled}
+        onValueChange={(next) =>
+          onValueChange(next ? { ...rect, unit: 'normalized' } : undefined)
+        }
+      />
+      <SectionSlider
+        label="ROI X"
+        description="Left edge of the region, normalized 0..1."
+        value={rect.x}
+        min={0}
+        max={1 - rect.width}
+        step={0.01}
+        disabled={!enabled}
+        onValueChange={(x) => updateRect({ x })}
+      />
+      <SectionSlider
+        label="ROI Y"
+        description="Top edge of the region, normalized 0..1."
+        value={rect.y}
+        min={0}
+        max={1 - rect.height}
+        step={0.01}
+        disabled={!enabled}
+        onValueChange={(y) => updateRect({ y })}
+      />
+      <SectionSlider
+        label="ROI Width"
+        description="Width of the region, normalized 0..1."
+        value={rect.width}
+        min={0.05}
+        max={1 - rect.x}
+        step={0.01}
+        disabled={!enabled}
+        onValueChange={(width) => updateRect({ width })}
+      />
+      <SectionSlider
+        label="ROI Height"
+        description="Height of the region, normalized 0..1."
+        value={rect.height}
+        min={0.05}
+        max={1 - rect.y}
+        step={0.01}
+        disabled={!enabled}
+        onValueChange={(height) => updateRect({ height })}
+      />
+    </>
+  );
+};
+
+export { RegionOfInterestControl };

--- a/example/src/components/ui/index.ts
+++ b/example/src/components/ui/index.ts
@@ -4,6 +4,7 @@ export { CameraControls } from './CameraControls';
 export { Divider } from './Divider';
 export { GithubFab } from './GithubFab';
 export { LinkCard } from './LinkCard';
+export { RegionOfInterestControl } from './RegionOfInterestControl';
 export { Section } from './Section';
 export { SectionImageInput } from './SectionImageInput';
 export { SectionPicker } from './SectionPicker';

--- a/example/src/components/views/CameraView.tsx
+++ b/example/src/components/views/CameraView.tsx
@@ -36,6 +36,7 @@ import {
   useTerminalStore,
 } from '../../stores';
 import { FpsGraphOverlay } from './FpsGraphOverlay';
+import { ROIOverlay } from './ROIOverlay';
 
 const normalizeResultObject = (data: unknown) => {
   if (data === null || data === undefined) return data;
@@ -327,6 +328,7 @@ const CameraView = forwardRef<CameraRef, CameraViewProps>(
               maxFps={FPS_GRAPH_MAX_SCALE}
             />
           )}
+          {sharedOptions.roi && <ROIOverlay roi={sharedOptions.roi} />}
         </Reanimated.View>
       </GestureDetector>
     );

--- a/example/src/components/views/ROIOverlay.tsx
+++ b/example/src/components/views/ROIOverlay.tsx
@@ -1,0 +1,41 @@
+import { StyleSheet, View } from 'react-native';
+import type { RegionOfInterest } from 'react-native-vision-camera-mlkit';
+import { useTheme } from '../../providers/ThemeProvider';
+
+type ROIOverlayProps = {
+  roi: RegionOfInterest;
+};
+
+const ROIOverlay = ({ roi }: ROIOverlayProps) => {
+  const { theme } = useTheme();
+
+  if (roi.unit === 'pixel') return null;
+
+  return (
+    <View
+      pointerEvents="none"
+      accessibilityLabel="Region of interest boundary"
+      style={[
+        styles.rect,
+        {
+          left: `${roi.x * 100}%`,
+          top: `${roi.y * 100}%`,
+          width: `${roi.width * 100}%`,
+          height: `${roi.height * 100}%`,
+          borderColor: theme.colors.primary,
+        },
+      ]}
+    />
+  );
+};
+
+const styles = StyleSheet.create({
+  rect: {
+    position: 'absolute',
+    borderWidth: 2,
+    borderStyle: 'dashed',
+    borderRadius: 4,
+  },
+});
+
+export { ROIOverlay };

--- a/example/src/components/views/index.ts
+++ b/example/src/components/views/index.ts
@@ -5,4 +5,5 @@ export { NoCameraPermissionErrorView } from './NoCameraPermissionErrorView';
 export { NoDeviceErrorView } from './NoDeviceErrorView';
 export { NoPluginErrorView } from './NoPluginErrorView';
 export { PortalSegmentedToggle } from './PortalSegmentedToggle';
+export { ROIOverlay } from './ROIOverlay';
 export { TerminalBottomSheet } from './TerminalBottomSheet';

--- a/example/src/screens/ImageScreen.tsx
+++ b/example/src/screens/ImageScreen.tsx
@@ -15,6 +15,7 @@ import {
 import {
   Button,
   Divider,
+  RegionOfInterestControl,
   Section,
   SectionImageInput,
   SectionPicker,
@@ -212,6 +213,10 @@ const ImageScreen = () => {
               }
             />
           )}
+          <RegionOfInterestControl
+            value={sharedOptions.roi}
+            onValueChange={(roi) => setSharedOption('roi', roi)}
+          />
           {pluginId === PLUGIN_ID.BARCODE_SCANNING && (
             <>
               <SectionSwitch

--- a/example/src/screens/SettingsScreen.tsx
+++ b/example/src/screens/SettingsScreen.tsx
@@ -1,6 +1,7 @@
 import { useRoute, type RouteProp } from '@react-navigation/native';
 import { ScrollView, StyleSheet } from 'react-native';
 import {
+  RegionOfInterestControl,
   Section,
   SectionPicker,
   SectionSlider,
@@ -252,6 +253,16 @@ const SettingsScreen = () => {
           description="Allow double tap gesture to flip the camera."
           value={enableDoubleTapGesture}
           onValueChange={setEnableDoubleTapGesture}
+        />
+      </Section>
+
+      <Section
+        title="Region of Interest"
+        description="Crop ML Kit processing to a rectangle of the frame."
+      >
+        <RegionOfInterestControl
+          value={sharedOptions.roi}
+          onValueChange={(roi) => setSharedOption('roi', roi)}
         />
       </Section>
     </ScrollView>

--- a/ios/Application/UseCases/RecognizeBarcodesUseCase.swift
+++ b/ios/Application/UseCases/RecognizeBarcodesUseCase.swift
@@ -39,7 +39,8 @@ import Foundation
             )
           }
 
-          return try recognitionService.recognize(image: processedImage)
+          let result = try recognitionService.recognize(image: processedImage)
+          return result.remapped(using: processedImage.metadata)
         }
       }
 
@@ -51,8 +52,10 @@ import Foundation
         return try autoreleasepool {
           let preprocessingOptions = ImagePreprocessingOptions(
             invertColors: imageOptions.invertColors,
+            outputOrientation: imageOptions.outputOrientation,
             scaleFactor: imageOptions.scaleFactor,
-            orientation: imageOptions.orientation
+            orientation: imageOptions.orientation,
+            roi: imageOptions.roi
           )
 
           guard
@@ -69,7 +72,8 @@ import Foundation
           }
 
           _ = barcodeOptions
-          return try recognitionService.recognize(image: processedImage)
+          let result = try recognitionService.recognize(image: processedImage)
+          return result.remapped(using: processedImage.metadata)
         }
       }
     }

--- a/ios/Application/UseCases/RecognizeTextUseCase.swift
+++ b/ios/Application/UseCases/RecognizeTextUseCase.swift
@@ -41,7 +41,8 @@ import Foundation
             )
           }
 
-          return try recognitionService.recognize(image: processedImage)
+          let result = try recognitionService.recognize(image: processedImage)
+          return result.remapped(using: processedImage.metadata)
         }
       }
 
@@ -66,7 +67,8 @@ import Foundation
             )
           }
 
-          return try recognitionService.recognize(image: processedImage)
+          let result = try recognitionService.recognize(image: processedImage)
+          return result.remapped(using: processedImage.metadata)
         }
       }
     }

--- a/ios/Bridge/Handlers/StaticBarcodeScanningHandler.swift
+++ b/ios/Bridge/Handlers/StaticBarcodeScanningHandler.swift
@@ -92,11 +92,35 @@ import Foundation
       let invertColors = options["invertColors"] as? Bool ?? false
       let orientation = (options["orientation"] as? String).flatMap { DomainOrientation(string: $0) }
       let scaleFactor = CGFloat((options["scaleFactor"] as? NSNumber)?.doubleValue ?? 1.0)
+      let roi = parseRegionOfInterest(options["roi"])
 
       return ImagePreprocessingOptions(
         invertColors: invertColors,
         scaleFactor: scaleFactor,
-        orientation: orientation
+        orientation: orientation,
+        roi: roi
+      )
+    }
+
+    private func parseRegionOfInterest(_ value: Any?) -> DomainRegionOfInterest? {
+      guard let dictionary = value as? [String: Any],
+        let x = (dictionary["x"] as? NSNumber)?.doubleValue,
+        let y = (dictionary["y"] as? NSNumber)?.doubleValue,
+        let width = (dictionary["width"] as? NSNumber)?.doubleValue,
+        let height = (dictionary["height"] as? NSNumber)?.doubleValue
+      else {
+        return nil
+      }
+
+      let unit: DomainRegionOfInterestUnit =
+        (dictionary["unit"] as? String) == "pixel" ? .pixel : .normalized
+
+      return DomainRegionOfInterest(
+        x: CGFloat(x),
+        y: CGFloat(y),
+        width: CGFloat(width),
+        height: CGFloat(height),
+        unit: unit
       )
     }
 

--- a/ios/Bridge/Handlers/StaticTextRecognitionHandler.swift
+++ b/ios/Bridge/Handlers/StaticTextRecognitionHandler.swift
@@ -98,10 +98,34 @@ import Foundation
     {
       let invertColors = options["invertColors"] as? Bool ?? false
       let orientation = (options["orientation"] as? String).flatMap { DomainOrientation(string: $0) }
+      let roi = parseRegionOfInterest(options["roi"])
 
       return ImagePreprocessingOptions(
         invertColors: invertColors,
-        orientation: orientation
+        orientation: orientation,
+        roi: roi
+      )
+    }
+
+    private func parseRegionOfInterest(_ value: Any?) -> DomainRegionOfInterest? {
+      guard let dictionary = value as? [String: Any],
+        let x = (dictionary["x"] as? NSNumber)?.doubleValue,
+        let y = (dictionary["y"] as? NSNumber)?.doubleValue,
+        let width = (dictionary["width"] as? NSNumber)?.doubleValue,
+        let height = (dictionary["height"] as? NSNumber)?.doubleValue
+      else {
+        return nil
+      }
+
+      let unit: DomainRegionOfInterestUnit =
+        (dictionary["unit"] as? String) == "pixel" ? .pixel : .normalized
+
+      return DomainRegionOfInterest(
+        x: CGFloat(x),
+        y: CGFloat(y),
+        width: CGFloat(width),
+        height: CGFloat(height),
+        unit: unit
       )
     }
 

--- a/ios/Bridge/Hybrid/BarcodeScannerOptions+toDomain.swift
+++ b/ios/Bridge/Hybrid/BarcodeScannerOptions+toDomain.swift
@@ -13,7 +13,8 @@ extension BarcodeScannerOptions {
   func toImagePreprocessingOptions() -> ImagePreprocessingOptions {
     return ImagePreprocessingOptions(
       invertColors: invertColors ?? false,
-      scaleFactor: CGFloat(scaleFactor ?? 1.0)
+      scaleFactor: CGFloat(scaleFactor ?? 1.0),
+      roi: roi?.toDomainRegionOfInterest()
     )
   }
 }

--- a/ios/Bridge/Hybrid/HybridBarcodeScanner.swift
+++ b/ios/Bridge/Hybrid/HybridBarcodeScanner.swift
@@ -34,7 +34,8 @@ final class HybridBarcodeScanner: HybridBarcodeScannerSpec {
         throw RuntimeError.error(withMessage: "Failed to preprocess VisionCamera frame.")
       }
 
-      return try recognitionService.recognize(image: processedImage).toNitroResult()
+      let result = try recognitionService.recognize(image: processedImage)
+      return result.remapped(using: processedImage.metadata).toNitroResult()
     #else
       throw RuntimeError.error(withMessage: "BarcodeScanning is not enabled in the native ML Kit configuration.")
     #endif

--- a/ios/Bridge/Hybrid/HybridTextRecognizer.swift
+++ b/ios/Bridge/Hybrid/HybridTextRecognizer.swift
@@ -34,7 +34,8 @@ final class HybridTextRecognizer: HybridTextRecognizerSpec {
         throw RuntimeError.error(withMessage: "Failed to preprocess VisionCamera frame.")
       }
 
-      return try recognitionService.recognize(image: processedImage).toNitroResult()
+      let result = try recognitionService.recognize(image: processedImage)
+      return result.remapped(using: processedImage.metadata).toNitroResult()
     #else
       throw RuntimeError.error(withMessage: "TextRecognition is not enabled in the native ML Kit configuration.")
     #endif

--- a/ios/Bridge/Hybrid/RegionOfInterest+toDomain.swift
+++ b/ios/Bridge/Hybrid/RegionOfInterest+toDomain.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension RegionOfInterest {
+  func toDomainRegionOfInterest() -> DomainRegionOfInterest {
+    let domainUnit: DomainRegionOfInterestUnit = unit == .pixel ? .pixel : .normalized
+    return DomainRegionOfInterest(
+      x: CGFloat(x),
+      y: CGFloat(y),
+      width: CGFloat(width),
+      height: CGFloat(height),
+      unit: domainUnit
+    )
+  }
+}

--- a/ios/Bridge/Hybrid/TextRecognizerOptions+toDomain.swift
+++ b/ios/Bridge/Hybrid/TextRecognizerOptions+toDomain.swift
@@ -12,7 +12,8 @@ extension TextRecognizerOptions {
   func toImagePreprocessingOptions() -> ImagePreprocessingOptions {
     return ImagePreprocessingOptions(
       invertColors: invertColors ?? false,
-      scaleFactor: CGFloat(scaleFactor ?? 1.0)
+      scaleFactor: CGFloat(scaleFactor ?? 1.0),
+      roi: roi?.toDomainRegionOfInterest()
     )
   }
 }

--- a/ios/Domain/Models/BarcodeScanningResult+remap.swift
+++ b/ios/Domain/Models/BarcodeScanningResult+remap.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+#if MLKIT_BARCODE_SCANNING
+  #if canImport(MLKitVision)
+    import MLKitVision
+
+    extension BarcodeScanningResult {
+      /// Remaps each barcode's bounding box and corner points back onto full-source-image
+      /// coordinates, undoing the ROI crop offset and preprocessing scale.
+      func remapped(using metadata: ImageMetadata) -> BarcodeScanningResult {
+        return BarcodeScanningResult(
+          barcodes: barcodes.map { $0.remapped(using: metadata) }
+        )
+      }
+    }
+
+    extension BarcodeData {
+      fileprivate func remapped(using metadata: ImageMetadata) -> BarcodeData {
+        return BarcodeData(
+          bounds: bounds?.remapped(using: metadata),
+          corners: corners?.map { $0.remapped(using: metadata) },
+          format: format,
+          formatName: formatName,
+          valueType: valueType,
+          valueTypeName: valueTypeName,
+          rawValue: rawValue,
+          displayValue: displayValue,
+          rawBytes: rawBytes,
+          isPotential: isPotential,
+          value: value
+        )
+      }
+    }
+  #endif
+#endif  // MLKIT_BARCODE_SCANNING

--- a/ios/Domain/Models/CoordinateRemap.swift
+++ b/ios/Domain/Models/CoordinateRemap.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+#if canImport(MLKitVision)
+  import MLKitVision
+
+  /// Shared primitive for mapping a processed-image coordinate (post-crop, post-scale) back onto
+  /// full-source-image coordinates: translate by the crop offset, then unscale.
+  /// `sourceX = offsetX + processedX / scaleFactor`.
+  /// Domain result coordinates are `Double` (matching `DomainBoundingBox`/`DomainCorner`), while
+  /// `ImageMetadata`'s offset/scale are `CGFloat`; both convert freely since neither loses
+  /// precision on 64-bit Apple platforms.
+  func remapPoint(x: Double, y: Double, metadata: ImageMetadata) -> (x: Double, y: Double) {
+    let scale = metadata.scaleFactor == 0 ? 1.0 : Double(metadata.scaleFactor)
+    return (
+      x: Double(metadata.offsetX) + x / scale,
+      y: Double(metadata.offsetY) + y / scale
+    )
+  }
+
+  extension DomainBoundingBox {
+    /// Remaps every coordinate field onto full-source-image coordinates using the given
+    /// preprocessing metadata. `width`/`height` only unscale (no translation), matching every
+    /// other field which translates by the crop offset then unscales.
+    func remapped(using metadata: ImageMetadata) -> DomainBoundingBox {
+      let scale = metadata.scaleFactor == 0 ? 1.0 : Double(metadata.scaleFactor)
+      let origin = remapPoint(x: x, y: y, metadata: metadata)
+      let center = remapPoint(x: centerX, y: centerY, metadata: metadata)
+      let topLeft = remapPoint(x: left, y: top, metadata: metadata)
+      let bottomRight = remapPoint(x: right, y: bottom, metadata: metadata)
+
+      return DomainBoundingBox(
+        x: origin.x,
+        y: origin.y,
+        centerX: center.x,
+        centerY: center.y,
+        width: width / scale,
+        height: height / scale,
+        top: topLeft.y,
+        left: topLeft.x,
+        bottom: bottomRight.y,
+        right: bottomRight.x
+      )
+    }
+  }
+
+  extension DomainCorner {
+    func remapped(using metadata: ImageMetadata) -> DomainCorner {
+      let point = remapPoint(x: x, y: y, metadata: metadata)
+      return DomainCorner(x: point.x, y: point.y)
+    }
+  }
+#endif

--- a/ios/Domain/Models/DomainRegionOfInterest.swift
+++ b/ios/Domain/Models/DomainRegionOfInterest.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+enum DomainRegionOfInterestUnit {
+  case normalized
+  case pixel
+}
+
+/// Domain-layer Region of Interest, distinct from the Nitro-bridge `RegionOfInterest`
+/// (see `RegionOfInterest+toDomain.swift` for the conversion), matching how `DomainOrientation`
+/// is kept separate from the Nitro `Orientation` type.
+struct DomainRegionOfInterest {
+  let x: CGFloat
+  let y: CGFloat
+  let width: CGFloat
+  let height: CGFloat
+  let unit: DomainRegionOfInterestUnit
+
+  init(
+    x: CGFloat,
+    y: CGFloat,
+    width: CGFloat,
+    height: CGFloat,
+    unit: DomainRegionOfInterestUnit = .normalized
+  ) {
+    self.x = x
+    self.y = y
+    self.width = width
+    self.height = height
+    self.unit = unit
+  }
+}
+
+enum RegionOfInterestValidationError: Error, LocalizedError {
+  case negativeOrigin(x: CGFloat, y: CGFloat)
+  case nonPositiveSize(width: CGFloat, height: CGFloat)
+  case normalizedOutOfBounds(x: CGFloat, width: CGFloat, y: CGFloat, height: CGFloat)
+
+  var errorDescription: String? {
+    switch self {
+    case .negativeOrigin(let x, let y):
+      return "Invalid RegionOfInterest: x and y must be >= 0 (got x=\(x), y=\(y))."
+    case .nonPositiveSize(let width, let height):
+      return
+        "Invalid RegionOfInterest: width and height must be > 0 (got width=\(width), height=\(height))."
+    case .normalizedOutOfBounds(let x, let width, let y, let height):
+      return
+        "Invalid RegionOfInterest: normalized x + width and y + height must be <= 1 (got x=\(x), width=\(width), y=\(y), height=\(height))."
+    }
+  }
+}
+
+extension DomainRegionOfInterest {
+  /// Mirrors the JS-side `validateRegionOfInterest` rules so native preprocessing fails fast
+  /// instead of producing a nonsensical crop deep inside the pipeline.
+  func validate() throws {
+    if x < 0 || y < 0 {
+      throw RegionOfInterestValidationError.negativeOrigin(x: x, y: y)
+    }
+
+    if width <= 0 || height <= 0 {
+      throw RegionOfInterestValidationError.nonPositiveSize(width: width, height: height)
+    }
+
+    if unit == .normalized && (x + width > 1 || y + height > 1) {
+      throw RegionOfInterestValidationError.normalizedOutOfBounds(
+        x: x, width: width, y: y, height: height
+      )
+    }
+  }
+
+  /// Resolves this region into a pixel rectangle clamped to the given image dimensions.
+  /// `imageWidth`/`imageHeight` must be in the same pixel space the crop will be applied to
+  /// (post-orientation-normalization, pre-scale).
+  func resolvedPixelRect(imageWidth: CGFloat, imageHeight: CGFloat) -> CGRect {
+    let (px, py, pw, ph): (CGFloat, CGFloat, CGFloat, CGFloat)
+    switch unit {
+    case .pixel:
+      (px, py, pw, ph) = (x, y, width, height)
+    case .normalized:
+      (px, py, pw, ph) = (x * imageWidth, y * imageHeight, width * imageWidth, height * imageHeight)
+    }
+
+    let left = max(0, min(px, imageWidth))
+    let top = max(0, min(py, imageHeight))
+    let right = max(left, min(px + pw, imageWidth))
+    let bottom = max(top, min(py + ph, imageHeight))
+    return CGRect(x: left, y: top, width: right - left, height: bottom - top)
+  }
+}

--- a/ios/Domain/Models/DomainTextRecognitionResult+remap.swift
+++ b/ios/Domain/Models/DomainTextRecognitionResult+remap.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+#if canImport(MLKitVision)
+  import MLKitVision
+
+  extension DomainTextRecognitionResult {
+    /// Remaps every bounding box and corner point in the result tree back onto full-source-image
+    /// coordinates, undoing the ROI crop offset and preprocessing scale. No-op when neither a
+    /// crop nor a scale was applied (offset is zero and scale is 1.0).
+    func remapped(using metadata: ImageMetadata) -> DomainTextRecognitionResult {
+      return DomainTextRecognitionResult(
+        text: text,
+        blocks: blocks.map { $0.remapped(using: metadata) }
+      )
+    }
+  }
+
+  extension DomainTextBlock {
+    fileprivate func remapped(using metadata: ImageMetadata) -> DomainTextBlock {
+      return DomainTextBlock(
+        text: text,
+        bounds: bounds?.remapped(using: metadata),
+        corners: corners?.map { $0.remapped(using: metadata) },
+        lines: lines.map { $0.remapped(using: metadata) },
+        languages: languages
+      )
+    }
+  }
+
+  extension DomainTextLine {
+    fileprivate func remapped(using metadata: ImageMetadata) -> DomainTextLine {
+      return DomainTextLine(
+        text: text,
+        bounds: bounds?.remapped(using: metadata),
+        corners: corners?.map { $0.remapped(using: metadata) },
+        elements: elements.map { $0.remapped(using: metadata) },
+        confidence: confidence,
+        angle: angle,
+        languages: languages
+      )
+    }
+  }
+
+  extension DomainTextElement {
+    fileprivate func remapped(using metadata: ImageMetadata) -> DomainTextElement {
+      return DomainTextElement(
+        text: text,
+        bounds: bounds?.remapped(using: metadata),
+        corners: corners?.map { $0.remapped(using: metadata) },
+        symbols: symbols.map { $0.remapped(using: metadata) },
+        confidence: confidence,
+        angle: angle,
+        languages: languages
+      )
+    }
+  }
+
+  extension DomainTextSymbol {
+    fileprivate func remapped(using metadata: ImageMetadata) -> DomainTextSymbol {
+      return DomainTextSymbol(
+        text: text,
+        bounds: bounds?.remapped(using: metadata),
+        corners: corners?.map { $0.remapped(using: metadata) },
+        confidence: confidence,
+        angle: angle,
+        languages: languages
+      )
+    }
+  }
+#endif

--- a/ios/Domain/Models/ImagePreprocessingOptions.swift
+++ b/ios/Domain/Models/ImagePreprocessingOptions.swift
@@ -5,16 +5,19 @@ public struct ImagePreprocessingOptions {
   let outputOrientation: OutputOrientation?
   let scaleFactor: CGFloat
   let orientation: DomainOrientation?
+  let roi: DomainRegionOfInterest?
 
   init(
     invertColors: Bool = false,
     outputOrientation: OutputOrientation? = nil,
     scaleFactor: CGFloat = 1.0,
-    orientation: DomainOrientation? = nil
+    orientation: DomainOrientation? = nil,
+    roi: DomainRegionOfInterest? = nil
   ) {
     self.invertColors = invertColors
     self.outputOrientation = outputOrientation
     self.scaleFactor = scaleFactor
     self.orientation = orientation
+    self.roi = roi
   }
 }

--- a/ios/Domain/Models/ProcessedImage.swift
+++ b/ios/Domain/Models/ProcessedImage.swift
@@ -13,5 +13,31 @@ import Foundation
     let height: Int
     let orientation: UIImage.Orientation
     let isInverted: Bool
+    /// Origin of the ROI crop, in the same pixel space as `width`/`height` (post-orientation,
+    /// pre-scale). Downstream code adds this back onto ML Kit result coordinates to remap them
+    /// to full-source-image coordinates. Zero when no ROI crop was applied.
+    let offsetX: CGFloat
+    let offsetY: CGFloat
+    /// Scale factor applied during preprocessing, needed to unscale result coordinates when
+    /// remapping them back to full-source-image coordinates.
+    let scaleFactor: CGFloat
+
+    init(
+      width: Int,
+      height: Int,
+      orientation: UIImage.Orientation,
+      isInverted: Bool,
+      offsetX: CGFloat = 0,
+      offsetY: CGFloat = 0,
+      scaleFactor: CGFloat = 1.0
+    ) {
+      self.width = width
+      self.height = height
+      self.orientation = orientation
+      self.isInverted = isInverted
+      self.offsetX = offsetX
+      self.offsetY = offsetY
+      self.scaleFactor = scaleFactor
+    }
   }
 #endif

--- a/ios/Infrastructure/Image/ImagePreprocessor.swift
+++ b/ios/Infrastructure/Image/ImagePreprocessor.swift
@@ -26,15 +26,34 @@ import Foundation
       return min(max(scale, 0.9), 1.0)
     }
 
-    // Create scaled VisionImage from CIImage using Core Image affine transform
+    // Create scaled VisionImage from CIImage using Core Image affine transform.
+    // Crop happens before scale, matching the static-image pipeline's crop-then-scale order.
     private func createScaledVisionImage(
       from ciImage: CIImage,
       scaleFactor: CGFloat,
       frameOrientation: UIImage.Orientation,
-      outputOrientation: OutputOrientation?
+      outputOrientation: OutputOrientation?,
+      roi: DomainRegionOfInterest?
     ) -> VisionImage? {
+      var workingImage = ciImage
+
+      if let roi = roi {
+        guard (try? roi.validate()) != nil else {
+          return nil
+        }
+        let extent = workingImage.extent
+        let pixelRect = roi.resolvedPixelRect(
+          imageWidth: extent.width,
+          imageHeight: extent.height
+        )
+        // CIImage's coordinate origin is at the extent's origin (not necessarily .zero),
+        // so the crop rect must be offset into the image's own coordinate space.
+        let cropRect = pixelRect.offsetBy(dx: extent.minX, dy: extent.minY)
+        workingImage = workingImage.cropped(to: cropRect)
+      }
+
       // Apply scaling using CIAffineTransform
-      let scaledCIImage = ciImage.transformed(
+      let scaledCIImage = workingImage.transformed(
         by: CGAffineTransform(scaleX: scaleFactor, y: scaleFactor)
       )
 
@@ -84,6 +103,12 @@ import Foundation
       let effectiveScale = clampScale(options.scaleFactor)
       let frameOrientation = frame.orientation.asUIImageOrientation
 
+      if let roi = options.roi {
+        guard (try? roi.validate()) != nil else {
+          return nil
+        }
+      }
+
       let image: VisionImage
 
       if options.invertColors {
@@ -92,36 +117,65 @@ import Foundation
             sampleBuffer: sampleBuffer,
             frameOrientation: frameOrientation,
             outputOrientation: options.outputOrientation,
-            scaleFactor: effectiveScale
+            scaleFactor: effectiveScale,
+            roi: options.roi
           )
         else {
           return nil
         }
         image = invertedImage
       } else {
-        image = createVisionImageFromFrame(
-          sampleBuffer: sampleBuffer,
-          frameOrientation: frameOrientation,
-          outputOrientation: options.outputOrientation,
-          scaleFactor: effectiveScale
-        )
+        guard
+          let convertedImage = createVisionImageFromFrame(
+            sampleBuffer: sampleBuffer,
+            frameOrientation: frameOrientation,
+            outputOrientation: options.outputOrientation,
+            scaleFactor: effectiveScale,
+            roi: options.roi
+          )
+        else {
+          return nil
+        }
+        image = convertedImage
       }
 
       guard let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
         return nil
       }
 
+      // Use pre-crop, pre-scale pixel-buffer dimensions to resolve the ROI's pixel rect so the
+      // crop offset lands in the same coordinate space as the scaled width/height below.
+      let originalWidth = CGFloat(CVPixelBufferGetWidth(imageBuffer))
+      let originalHeight = CGFloat(CVPixelBufferGetHeight(imageBuffer))
+
+      var offsetX: CGFloat = 0
+      var offsetY: CGFloat = 0
+      var croppedWidth = originalWidth
+      var croppedHeight = originalHeight
+
+      if let roi = options.roi {
+        let pixelRect = roi.resolvedPixelRect(
+          imageWidth: originalWidth,
+          imageHeight: originalHeight
+        )
+        offsetX = pixelRect.origin.x
+        offsetY = pixelRect.origin.y
+        croppedWidth = pixelRect.width
+        croppedHeight = pixelRect.height
+      }
+
       // Use scaled dimensions for metadata
-      let originalWidth = CVPixelBufferGetWidth(imageBuffer)
-      let originalHeight = CVPixelBufferGetHeight(imageBuffer)
-      let width = Int(CGFloat(originalWidth) * effectiveScale)
-      let height = Int(CGFloat(originalHeight) * effectiveScale)
+      let width = Int(croppedWidth * effectiveScale)
+      let height = Int(croppedHeight * effectiveScale)
 
       let metadata = ImageMetadata(
         width: width,
         height: height,
         orientation: frameOrientation,
-        isInverted: options.invertColors
+        isInverted: options.invertColors,
+        offsetX: offsetX,
+        offsetY: offsetY,
+        scaleFactor: effectiveScale
       )
 
       return ProcessedImage(image: image, metadata: metadata)
@@ -131,8 +185,9 @@ import Foundation
       sampleBuffer: CMSampleBuffer,
       frameOrientation: UIImage.Orientation,
       outputOrientation: OutputOrientation?,
-      scaleFactor: CGFloat
-    ) -> VisionImage {
+      scaleFactor: CGFloat,
+      roi: DomainRegionOfInterest?
+    ) -> VisionImage? {
       // MLKit works more reliably when frames are converted to UIImage
       // YUV CMSampleBuffer can have orientation and format handling issues
       if let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) {
@@ -151,23 +206,27 @@ import Foundation
           || pixelFormatType
             == kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarFullRange
 
-        // Force conversion when scaling is needed to ensure consistent behavior
-        // Never bypass scaling if scaleFactor < 1.0
-        if needsConversion || scaleFactor < 1.0 {
-          if let convertedImage = convertToSupportedFormat(
-            pixelBuffer: pixelBuffer,
-            frameOrientation: frameOrientation,
-            outputOrientation: outputOrientation,
-            scaleFactor: scaleFactor
-          ) {
-            return convertedImage
+        // Force conversion when scaling or an ROI crop is needed to ensure consistent behavior.
+        // Never bypass scaling/cropping if scaleFactor < 1.0 or an ROI is set, since the raw
+        // CMSampleBuffer fast path below cannot crop.
+        if needsConversion || scaleFactor < 1.0 || roi != nil {
+          guard
+            let convertedImage = convertToSupportedFormat(
+              pixelBuffer: pixelBuffer,
+              frameOrientation: frameOrientation,
+              outputOrientation: outputOrientation,
+              scaleFactor: scaleFactor,
+              roi: roi
+            )
+          else {
+            // Conversion failed - this should not happen for scaling/cropping cases
+            return nil
           }
-          // Conversion failed - this should not happen for scaling cases
-          fatalError("Conversion failed when scaling is required")
+          return convertedImage
         }
       }
 
-      // Fallback: Use CMSampleBuffer directly (for BGRA and scaleFactor == 1.0)
+      // Fallback: Use CMSampleBuffer directly (for BGRA, scaleFactor == 1.0, and no ROI)
       let image = VisionImage(buffer: sampleBuffer)
       image.orientation = getVisionOrientation(
         frameOrientation: frameOrientation,
@@ -180,7 +239,8 @@ import Foundation
       sampleBuffer: CMSampleBuffer,
       frameOrientation: UIImage.Orientation,
       outputOrientation: OutputOrientation?,
-      scaleFactor: CGFloat
+      scaleFactor: CGFloat,
+      roi: DomainRegionOfInterest?
     ) -> VisionImage? {
       guard let buffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
         return nil
@@ -197,7 +257,8 @@ import Foundation
         from: invertedCIImage,
         scaleFactor: scaleFactor,
         frameOrientation: frameOrientation,
-        outputOrientation: outputOrientation
+        outputOrientation: outputOrientation,
+        roi: roi
       )
     }
 
@@ -231,7 +292,8 @@ import Foundation
       pixelBuffer: CVPixelBuffer,
       frameOrientation: UIImage.Orientation,
       outputOrientation: OutputOrientation?,
-      scaleFactor: CGFloat
+      scaleFactor: CGFloat,
+      roi: DomainRegionOfInterest?
     ) -> VisionImage? {
       // Convert to CIImage
       let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
@@ -241,7 +303,8 @@ import Foundation
         from: ciImage,
         scaleFactor: scaleFactor,
         frameOrientation: frameOrientation,
-        outputOrientation: outputOrientation
+        outputOrientation: outputOrientation,
+        roi: roi
       )
     }
 
@@ -260,6 +323,40 @@ import Foundation
       let effectiveScale = clampScale(options.scaleFactor)
 
       var processedImage = uiImage
+      var offsetX: CGFloat = 0
+      var offsetY: CGFloat = 0
+
+      // Apply optional ROI crop, right after decode/orientation-resolution and before
+      // scale/invert (UIImage.imageOrientation metadata already encodes orientation for the
+      // static path, so there's no separate rotate step here).
+      if let roi = options.roi {
+        guard (try? roi.validate()) != nil else {
+          return nil
+        }
+
+        // Crop in the same pixel space ML Kit will see: the CGImage's pixel dimensions,
+        // not the orientation-aware `image.size`.
+        guard let cgImage = processedImage.cgImage else {
+          return nil
+        }
+
+        let pixelRect = roi.resolvedPixelRect(
+          imageWidth: CGFloat(cgImage.width),
+          imageHeight: CGFloat(cgImage.height)
+        )
+
+        guard let croppedCGImage = cgImage.cropping(to: pixelRect) else {
+          return nil
+        }
+
+        offsetX = pixelRect.origin.x
+        offsetY = pixelRect.origin.y
+        processedImage = UIImage(
+          cgImage: croppedCGImage,
+          scale: processedImage.scale,
+          orientation: processedImage.imageOrientation
+        )
+      }
 
       // Apply optional downscale for static images.
       if effectiveScale < 1.0 {
@@ -287,7 +384,10 @@ import Foundation
         width: pixelWidth,
         height: pixelHeight,
         orientation: visionOrientation,
-        isInverted: options.invertColors
+        isInverted: options.invertColors,
+        offsetX: offsetX,
+        offsetY: offsetY,
+        scaleFactor: effectiveScale
       )
 
       return ProcessedImage(image: visionImage, metadata: metadata)

--- a/src/__tests__/validateRegionOfInterest.test.ts
+++ b/src/__tests__/validateRegionOfInterest.test.ts
@@ -1,0 +1,82 @@
+import { validateRegionOfInterest } from '../core/validateRegionOfInterest';
+import type { RegionOfInterest } from '../core/types';
+
+describe('validateRegionOfInterest', () => {
+  it('accepts a valid normalized region', () => {
+    expect(() =>
+      validateRegionOfInterest({ x: 0.25, y: 0.25, width: 0.5, height: 0.5 })
+    ).not.toThrow();
+  });
+
+  it('accepts a valid normalized region with unit explicitly set', () => {
+    expect(() =>
+      validateRegionOfInterest({
+        x: 0,
+        y: 0,
+        width: 1,
+        height: 1,
+        unit: 'normalized',
+      })
+    ).not.toThrow();
+  });
+
+  it('accepts a valid pixel region regardless of magnitude', () => {
+    expect(() =>
+      validateRegionOfInterest({
+        x: 100,
+        y: 100,
+        width: 800,
+        height: 600,
+        unit: 'pixel',
+      })
+    ).not.toThrow();
+  });
+
+  it('throws when x is negative', () => {
+    expect(() =>
+      validateRegionOfInterest({ x: -0.1, y: 0, width: 0.5, height: 0.5 })
+    ).toThrow(/x and y must be >= 0/);
+  });
+
+  it('throws when y is negative', () => {
+    expect(() =>
+      validateRegionOfInterest({ x: 0, y: -0.1, width: 0.5, height: 0.5 })
+    ).toThrow(/x and y must be >= 0/);
+  });
+
+  it('throws when width is zero or negative', () => {
+    expect(() =>
+      validateRegionOfInterest({ x: 0, y: 0, width: 0, height: 0.5 })
+    ).toThrow(/width and height must be > 0/);
+  });
+
+  it('throws when height is zero or negative', () => {
+    expect(() =>
+      validateRegionOfInterest({ x: 0, y: 0, width: 0.5, height: -1 })
+    ).toThrow(/width and height must be > 0/);
+  });
+
+  it('throws when normalized x + width exceeds 1', () => {
+    expect(() =>
+      validateRegionOfInterest({ x: 0.6, y: 0, width: 0.5, height: 0.5 })
+    ).toThrow(/x \+ width and y \+ height must be <= 1/);
+  });
+
+  it('throws when normalized y + height exceeds 1', () => {
+    expect(() =>
+      validateRegionOfInterest({ x: 0, y: 0.6, width: 0.5, height: 0.5 })
+    ).toThrow(/x \+ width and y \+ height must be <= 1/);
+  });
+
+  it('does not apply the normalized bounds check for pixel regions', () => {
+    const roi: RegionOfInterest = {
+      x: 500,
+      y: 500,
+      width: 500,
+      height: 500,
+      unit: 'pixel',
+    };
+
+    expect(() => validateRegionOfInterest(roi)).not.toThrow();
+  });
+});

--- a/src/core/NativeBridge.ts
+++ b/src/core/NativeBridge.ts
@@ -1,7 +1,8 @@
 import { Platform } from 'react-native';
 import VisionCameraMLKitModule from '../VisionCameraMLKitSpec';
 import { INVALID_URI_ERROR, MISSING_MODULE_ERROR } from '../shared/constants';
-import type { MLKitFeature } from './types';
+import { validateRegionOfInterest } from './validateRegionOfInterest';
+import type { ImageProcessingBaseOptions, MLKitFeature } from './types';
 
 /**
  * Bridge class for native MLKit image processing
@@ -17,7 +18,7 @@ export class NativeBridge {
   static async processImage(
     feature: MLKitFeature,
     uri: string,
-    options: object = {}
+    options: ImageProcessingBaseOptions = {}
   ): Promise<any> {
     if (
       !VisionCameraMLKitModule ||
@@ -26,6 +27,10 @@ export class NativeBridge {
       throw new Error(MISSING_MODULE_ERROR);
     }
     const normalizedUri = this.validateAndNormalizeUri(uri);
+
+    if (options.roi) {
+      validateRegionOfInterest(options.roi);
+    }
 
     return await VisionCameraMLKitModule.processImage(
       feature,

--- a/src/core/PluginFactory.ts
+++ b/src/core/PluginFactory.ts
@@ -3,6 +3,7 @@ import { FEATURE_ERROR_MAP } from '../shared/constants';
 import type { BarcodeScanningOptions } from '../features/barcode-scanning/types';
 import type { TextRecognitionOptions } from '../features/text-recognition/types';
 import { MLKIT_FEATURE_KEYS } from './constants';
+import { validateRegionOfInterest } from './validateRegionOfInterest';
 import { VisionCameraMLKit } from './VisionCameraMLKit';
 import type { MLKitBaseOptions, MLKitFeature } from './types';
 
@@ -73,6 +74,10 @@ buildscript {
    */
   static initPlugin(feature: MLKitFeature, options: MLKitBaseOptions) {
     PluginFactory.assertFeatureAvailable(feature);
+
+    if (options.roi) {
+      validateRegionOfInterest(options.roi);
+    }
 
     switch (feature) {
       case MLKIT_FEATURE_KEYS.TEXT_RECOGNITION:

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -21,6 +21,30 @@ export type Corner = {
   y: number;
 };
 
+/**
+ * Whether a {@link RegionOfInterest}'s `x`/`y`/`width`/`height` are
+ * normalized to the `0..1` range (relative to the source frame/image) or
+ * absolute pixel values.
+ */
+export type RegionOfInterestUnit = 'normalized' | 'pixel';
+
+/**
+ * Restricts ML Kit processing to a rectangular region of the source
+ * frame/image. Cropping happens before recognition to reduce CPU/GPU work;
+ * result coordinates (bounding boxes, corners) are always mapped back to
+ * full source coordinates, so overlays don't need to know a crop happened.
+ */
+export type RegionOfInterest = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /**
+   * @default 'normalized'
+   */
+  unit?: RegionOfInterestUnit;
+};
+
 export type MLKitBaseOptions = {
   /**
    * Optional image downscaling for performance optimization.
@@ -34,6 +58,12 @@ export type MLKitBaseOptions = {
    * @default false
    */
   invertColors?: boolean;
+  /**
+   * Crop processing to a rectangular region of the frame before running
+   * ML Kit, to reduce CPU/GPU work. Result coordinates are mapped back to
+   * full source coordinates.
+   */
+  roi?: RegionOfInterest;
   /**
    * @deprecated Throttle frames manually inside your `useFrameOutput` `onFrame` callback instead.
    * Process one frame, then skip the next N frames before processing again.
@@ -92,6 +122,12 @@ export type ImageProcessingBaseOptions = {
    * @default false
    */
   invertColors?: boolean;
+  /**
+   * Crop processing to a rectangular region of the image before running
+   * ML Kit, to reduce CPU/GPU work. Result coordinates are mapped back to
+   * full source coordinates.
+   */
+  roi?: RegionOfInterest;
 };
 
 export type ImageProcessingError =

--- a/src/core/validateRegionOfInterest.ts
+++ b/src/core/validateRegionOfInterest.ts
@@ -1,0 +1,29 @@
+import type { RegionOfInterest } from './types';
+
+/**
+ * Validates a {@link RegionOfInterest} before it crosses into native code.
+ * Fails fast on out-of-bounds values instead of letting native preprocessing
+ * fail deep inside the crop step.
+ * @throws {Error} If the region is invalid for its unit.
+ */
+export const validateRegionOfInterest = (roi: RegionOfInterest): void => {
+  const { x, y, width, height, unit = 'normalized' } = roi;
+
+  if (x < 0 || y < 0) {
+    throw new Error(
+      `Invalid RegionOfInterest: x and y must be >= 0 (got x=${x}, y=${y}).`
+    );
+  }
+
+  if (width <= 0 || height <= 0) {
+    throw new Error(
+      `Invalid RegionOfInterest: width and height must be > 0 (got width=${width}, height=${height}).`
+    );
+  }
+
+  if (unit === 'normalized' && (x + width > 1 || y + height > 1)) {
+    throw new Error(
+      `Invalid RegionOfInterest: normalized x + width and y + height must be <= 1 (got x=${x}, width=${width}, y=${y}, height=${height}).`
+    );
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ export {
   type MLKitBaseOptions,
   type MLKitFeature,
   type Orientation,
+  type RegionOfInterest,
+  type RegionOfInterestUnit,
 } from './core/types';
 
 export type { BarcodeScanner } from './specs/BarcodeScanner.nitro';

--- a/src/specs/MLKitVisionTypes.ts
+++ b/src/specs/MLKitVisionTypes.ts
@@ -1,5 +1,6 @@
 import type { BarcodeFormat } from '../features/barcode-scanning/types';
 import type { TextRecognitionLanguage } from '../features/text-recognition/types';
+import type { RegionOfInterest } from '../core/types';
 
 /**
  * ML Kit features that can be compiled into this package.
@@ -35,6 +36,13 @@ export interface MLKitRecognizerOptions {
    * Legacy frame skipping option kept for compatibility while v5 examples use frame output throttling.
    */
   frameProcessInterval?: number;
+
+  /**
+   * Crop processing to a rectangular region of the frame before running
+   * ML Kit, to reduce CPU/GPU work. Result coordinates are mapped back to
+   * full source frame coordinates.
+   */
+  roi?: RegionOfInterest;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a shared `roi` option so consumers can crop ML Kit processing to a rectangle of the frame/image, reducing CPU/GPU work for both text recognition and barcode scanning.

The implementation supports both the live-camera-frame path and the static-image path, on Android and iOS, with result coordinates (bounding boxes, corner points) always mapped back to full source-frame/image coordinates so existing overlay code doesn't need to know a crop happened.

## Context

Restricting processing to a specific region has been a known gap: every recognition call today runs ML Kit over the full frame/image even when a consumer only cares about a sub-region (e.g. a scan window in a barcode-scanning UI), wasting CPU/GPU work. This PR adds that capability as a shared preprocessing option so it benefits both existing features (text recognition, barcode scanning) and any future ML Kit feature added on top of the same preprocessing layer.

## What was implemented

### Public capability

- Added `roi?: RegionOfInterest` to `MLKitBaseOptions` (live-frame path) and `ImageProcessingBaseOptions` (static-image path), consumed identically by `useTextRecognition`/`useBarcodeSca`processImageTextRecognition`/`processImageBarcodeScanning`.
- `RegionOfInterest` accepts `x`/`y to `0..1` by default (relative tothe source frame/image), or absolute pixel values via `unit: 'pixel'`.
- A JS-side validator (`validateRegth a clear error before any nativecall, on both the creation-time (frame) and per-call (static-image) paths.

### Native / backend / internal integration

- **Android & iOS**: crop is inserted after rotation/orientation-normalization and before
scale/invert, on both the live-framegacy bridge) paths, for bothfeatures.
- The pre-existing "fast path" thatessing entirely when no scale orinvert was needed is now also disabled whenever an ROI is set, since it can't crop.
- Added a shared coordinate-remap p` / `CoordinateRemap.swift`) thattranslates result bounding boxes and corner points back to full source coordinates using the recorded
crop offset and scale factor, applinition's block→line→element→symboltree and flatly for barcode results.
- Extended the Nitro spec (`MLKitReated bindings so `roi` actuallycrosses the JS/native bridge for the live-frame path; added manual dictionary/`ReadableMap` parsing
for the static-image bridge path.

### Documentation and examples

- Added a `roi` row to every optiontext-recognition.md`, and`docs/barcode-scanning.md`, plus a "Region of Interest" reference section in the main README.
- Added a real Settings-tab ROI conlized sliders) shared between theCamera and Image screens in the example app, plus a live `ROIOverlay` rectangle rendered over the
camera preview for visual verificat

## Public API

```ts
import { useTextRecognition } from 'react-native-vision-camera-mlkit';

const { textRecognition } = useTextRecognition({
  roi: { x: 0.25, y: 0.25, width: 0
});
```

### New or updated options

| Option | Type                | De      | Platform |
| ------ | ------------------- |--------------------------------------------------------------------------- | -------- |
| `roi`  | `RegionOfInterest`  | Cr of the frame/image; results remapped back to source coordinates | Android, iOS |

## Platform behavior

| Platform | Status    | Notes                                                                 |
| -------- | --------- | ----------------------------------------- |
| Android  | Supported | Crop via `Bitmap.createBitmap`; remap applied before Nitro serialization |
| iOS      | Supported | Crop via `c) / `CIImage.cropped(to:)` (frame) |

## Validation

- [x] Unit tests — added for `validnvalid normalized and pixel regions)
- [x] `yarn typecheck`, `yarn lint`, `yarn test --runInBand`, `yarn prepare` all green
- [ ] Android build — not verified ain available in the dev environmentthis was built in)
- [ ] iOS build — two build errors ual verification (stale CocoaPodsheader cache after adding new Nitro-generated files; a Swift filename collision between the domain
`RegionOfInterest.swift` and the Nie name, resolved by renaming to`DomainRegionOfInterest.swift`); final successful build/run has not yet been confirmed
- [ ] Android device validation — p
- [ ] iOS device validation — pending
- [ ] Example application validatiotrol and overlay are implemented butnot yet exercised on-device)
- [x] Documentation reviewed
- [x] Kotlin verified with `ktlint` (2 minor formatting issues found and auto-fixed, confirmed no
logic change); Swift verified with epo's own `.swift-format` config(clean; a handful of SwiftLint findings were checked against the pre-ROI baseline and confirmed
pre-existing, not introduced by thi

### Evidence

```text
yarn test --runInBand
Test Suites: 2 passed, 2 total
Tests:       14 passed, 14 total
```

## Compatibility considerations

- `roi` is optional and defaults toy additive, no breaking API change.
- No new dependencies.
- **Behavior fix bundled in**: builROI surfaced and fixed a pre-existing gap where the existing `scaleFactor` option never remapped result coordinates back to source space —
results from a downscaled image werdownscaled image's own pixel space.Consumers already using `scaleFactor` will see bounding-box coordinates shift (correctly) to match
full source-frame coordinates.
- Also fixed, while wiring iOS: a static-image barcode-scanning path was silently dropping
`outputOrientation` when reconstrucnd a `CMSampleBuffer`conversion-failure path used `fatalError` instead of failing gracefully — the latter is now reachable
via ROI validation failures in normed to return `nil` instead ofcrashing.

## Follow-up work

* [ ] On-device Android and iOS validation (build + manual ROI/overlay/remap check)
* [ ] Native unit tests for the preone exist in this repo today foreither platform; out of scope for this PR

## Reviewer notes

Review focus:

* `CoordinateRemap.kt` / `CoordinateRemap.swift` — the actual remap math (`source = offset +
processed / scaleFactor`) lives in m and is reused by both features.
* The fast-path disablement in `HybridFrameSpec+toProcessedImage.kt` (Android) and
`ImagePreprocessor.swift`'s `create easy to silently regress if a future change reintroduces a raw-buffer shortcut without checking `roi != nil`.
* iOS domain type naming (`DomainRee file rename) — follows the existing `DomainOrientation`/`Orientation` precedent for avoiding collisions with Nitro-generated types.
* The `scaleFactor` coordinate-remaabove — confirm this is acceptable as a bundled fix rather than a separate PR.