### PR TITLE
fix(example): replace @gorhom/bottom-sheet with @swmansion/react-native-bottom-sheet

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2115,6 +2115,28 @@ PODS:
     - React-perflogger (= 0.86.0)
     - React-utils (= 0.86.0)
     - ReactNativeDependencies
+  - ReactNativeBottomSheet (0.17.0-next.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - ReactNativeDependencies (0.86.0)
   - RNGestureHandler (3.0.2):
     - hermes-engine
@@ -2586,6 +2608,7 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios/ReactAppDependencyProvider`)
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "ReactNativeBottomSheet (from `../node_modules/@swmansion/react-native-bottom-sheet`)"
   - ReactNativeDependencies (from `../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
@@ -2779,6 +2802,8 @@ EXTERNAL SOURCES:
     :path: build/generated/ios/ReactCodegen
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  ReactNativeBottomSheet:
+    :path: "../node_modules/@swmansion/react-native-bottom-sheet"
   ReactNativeDependencies:
     :podspec: "../node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec"
   RNGestureHandler:
@@ -2822,96 +2847,97 @@ SPEC CHECKSUMS:
   MLKitTextRecognitionKorean: 4877b6a8d95cd8846586e83f85b2f3e9ac93a737
   MLKitVision: e858c5f125ecc288e4a31127928301eaba9ae0c1
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
-  NitroImage: 2f592086cbdecbbaa1c10dd97e0cdd43b1bb0817
-  NitroModules: b4174dd303728e16ad1afb79f64c1a5c69a3b373
+  NitroImage: 0bbe0fc7032343a8e574e9ebcfafbbd81e1b37c2
+  NitroModules: 7e004af1d2cbc3072b071de62aeb9c147ef79d34
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f
-  RCTSwiftUIWrapper: ab2ca548be15d63afa95103afc8685a7c3eab78b
+  RCTSwiftUIWrapper: 1feaf484029fd6294fe8bc401d28e1d803eca142
   RCTTypeSafety: 3eaed17dbddb0b989208b062ea14c44d412b9780
   React: 2574546f2d017abd14d0c9b48cf2b6a0547c2591
   React-callinvoker: 03cd4b931d1d583d87aae99b8f7b6fe26bf571ee
-  React-Core: 1c824d9c7dd8aa760b5f1b50d5a54c2a3f598f87
+  React-Core: b0a0038e05720fb8148759404e9c354e3e60043c
   React-Core-prebuilt: 7da85c26e5616d52f119b81ce5e3e6fc5c9bda49
-  React-CoreModules: 2f9ed75bca7f6dea2b70e8a1f4a5ca9b6be52d76
-  React-cxxreact: 7103d5ba69848c039e11079e74ceede05efe795e
+  React-CoreModules: a1121b3182200be11e078940159c67ff95ee98b4
+  React-cxxreact: 8f74977959064bee99af63bb0ad95b6c3dbec921
   React-debug: 8cc8d99ccc664ef9e873027f7fc3fb0a50496012
-  React-defaultsnativemodule: 603c108411d39d7bb5ccb8c270f1f50cb6207e10
-  React-domnativemodule: c49a502edc85f515a029c341fe5fba155fa6675c
-  React-Fabric: acc4915d719db793c5853e5c74b54ea5aa48e865
-  React-FabricComponents: aebebc98914a4a8fc962fa7b5b98ebaf250acb68
-  React-FabricImage: 42e99e48ff73c8b20cee229e622977d0b97b6247
-  React-featureflags: c6d8d8d52acf3a956485726076b73eeff7935340
-  React-featureflagsnativemodule: c992de92dcf30dcf09efdec17752abe4128ec55f
-  React-graphics: 239fd9b0512e539d3563f0825618f4e49795eefd
-  React-hermes: ae4685ca9fa5f47003bc594d3f146e29284136d1
-  React-idlecallbacksnativemodule: 10a5be842ab181953c772a3f28cdf94572833eb0
-  React-ImageManager: c36a56c3b13eba92e1d0d30da35d0a1ccf29cd6c
-  React-intersectionobservernativemodule: 71404bfa47d31e4143cc9db3e26178b5cfcd07e1
-  React-jserrorhandler: ca2eeb03c1a77bbfab1b5425b943e3e8d92295f2
-  React-jsi: c4b6daf8a31ac54f2db49cd6cce29720fec1f3a8
-  React-jsiexecutor: acdc1a217b7ea29bcf6315b770d01e6b1c2fca14
-  React-jsinspector: 95d6394efe9fb4a64ed33afc076b32a6384c8514
-  React-jsinspectorcdp: 6ce51378a552feaaaac1a7b0d995fa0c49fa4f8c
-  React-jsinspectornetwork: 0db435c9264f200635fdf294a3b643dd3946d4cf
-  React-jsinspectortracing: 2e4470e1f301ff597bd65299aa95da4bae6e5c4f
-  React-jsitooling: 796bc991cdce68e2cc059d0271a28e0d4f8b0891
-  React-jsitracing: f3008e7b5e1d9de8d9f2ca1b85824ed86b0cea00
-  React-logger: fff73f4ceecad968c97baafdc77dcf84befc38b6
-  React-Mapbuffer: ce449ccdf3b80384415b925606be8a4bdcfc65d3
-  React-microtasksnativemodule: 2eb3f49d0d8e77b5343455eccd057010b8d38b6b
-  React-mutationobservernativemodule: f0a0d5ae9b51caf7becbeabf836d716cfedb6bf2
-  react-native-blur: ea6c78ddeaa7aa0fce36ea29d1f81dd23063032a
-  react-native-image-picker: 23540feacc79c63c60857f318fdfa8477c26e70a
-  react-native-safe-area-context: 91a90d98c310adcc90a511e5aeb6046d7c19d885
-  react-native-slider: f9910f69950b9953c46e091377c1265b71eb01f0
-  React-NativeModulesApple: a092d89b58f635ebfab88048b0eda9fb516819fd
-  React-networking: 968bbbe73590149feb1e72b2af4f6a68e4796ece
+  React-defaultsnativemodule: 7c8182addbb79ec576c589186b51e3fb405da7da
+  React-domnativemodule: 576bd1e6ad81477997dcb556e6db1f005134356b
+  React-Fabric: 4cbd22315ddb9e33441437f851117d314d1b4ad3
+  React-FabricComponents: efe374aecaf1bbc2fb9a195ece4b50fd9f66bfa0
+  React-FabricImage: cfeffc0b527de8bc2dc5a50618dad119361d0ec3
+  React-featureflags: 98931b22f5f4b861a3985b75bd79c5fcbe4618ab
+  React-featureflagsnativemodule: 518c2e279cdb3835604f7e8fb15f4c2691336b4c
+  React-graphics: ac9ff09da733d98c0e5eddb589dc7f9f082c9531
+  React-hermes: bd1a14a982e63ee75e9c9cb8d11d3d4b5f330196
+  React-idlecallbacksnativemodule: b6378d3bca83d8284e1abaa51251ee1ce570d85a
+  React-ImageManager: 4936349da191d1bc29ed2bbaf5a2dd74bfdf5ed8
+  React-intersectionobservernativemodule: d9a6451f2aa1f1c989d5d5e0d967db2c07d0c48c
+  React-jserrorhandler: 2455567e21fcc036f96015b2b8eb4eb13e0d8d05
+  React-jsi: bf5ec8e7a7b26bddc39ab7f821af5aad8bb94a33
+  React-jsiexecutor: cf6c957f578dd491ec8ae516a39aff2cf7369f1a
+  React-jsinspector: 63e9b9f9a5b6c51bf38deea2b379a63754c0ab0d
+  React-jsinspectorcdp: 327082854cdebb1f500a669c51146b9fd871058c
+  React-jsinspectornetwork: bbc5c2e881252075d63dc679f18cd856c2def94e
+  React-jsinspectortracing: ea6ec857ead0de4e6bbb2e12ee48ae4381938874
+  React-jsitooling: 52e278666b35e856414d613d7dc50d1f0d50d9a5
+  React-jsitracing: 642172314677a1d1780b81f4e2e4a3f4d3ccf238
+  React-logger: 35cda3ab8977c6c4546e3cf6dc8f91bacec25934
+  React-Mapbuffer: c058c051f571589e37a29bce18d0e9b730faa9d0
+  React-microtasksnativemodule: 03752e60738a797bb49f4d6cb0291dfa398099b8
+  React-mutationobservernativemodule: 2e568e13c98bd185fe83266795233fa7ad2cbc19
+  react-native-blur: baf5874b4abf3bb8b2012172a3d0905653a1a2b5
+  react-native-image-picker: 2146157d5d37a34c2063d1d2ed01081b56d0b87b
+  react-native-safe-area-context: 3cd1f988c96f187e15b49b86b0a2068a6cb19393
+  react-native-slider: 73473ab537b86b7ca1b21a28d16019d3cb63e927
+  React-NativeModulesApple: a4713821c9caae40ae33eef933a6e692a6f4a81d
+  React-networking: b344a1a41a4729ef859123b7a234f3092761cb25
   React-oscompat: 0b72a7e926954a0415ccd83e0748b6561fe45367
-  React-perflogger: 865984e492514aa6e5279fc3e663132cfa4d5022
-  React-performancecdpmetrics: 2efbf9bdb48c8d8446f4dd10e8bf0dc5d711772f
-  React-performancetimeline: 9d256484bff1513481be9f234baba694dc3b52e2
+  React-perflogger: a0d581c6cc174e847877107ddac3f4fc9b518dc7
+  React-performancecdpmetrics: 91d3d0dce2e3a239ea68cc2882e75b11a61cbf2e
+  React-performancetimeline: 4b9e04002c1ddba95167276a86424e5face65605
   React-RCTActionSheet: 902c79deec52f99cc48b1051b59bcbe86787d339
-  React-RCTAnimation: 09cf722039ae30ff5d64e2b011ff054ae651c3b6
-  React-RCTAppDelegate: a47de6fddb7eb0c028abba83138a5ce283bd7e77
-  React-RCTBlob: 38c418d067e0c61818223503063310122e44c588
-  React-RCTFabric: 480ca2a105730e1790cfd13291d086cb53725825
-  React-RCTFBReactNativeSpec: 63131378510a5191515a4adfc308e65b465106f4
-  React-RCTImage: 3ce36f82441b76b715818ee7ee95f6f5b34f9ee1
-  React-RCTLinking: 2f7b5ed4983122e5115732d25a4360960eab583c
-  React-RCTNetwork: dcd3b180f33da86f5dc5e928a816eb5464fa7f16
-  React-RCTRuntime: 6ef8e778fbab426b12eb5a9b5f7a0e86313c5a10
-  React-RCTSettings: b97727ec8c55c35bd284457a647c938c040b942b
-  React-RCTText: 4d1b88f6d3e1a43afe46706d956ec6664c87b984
-  React-RCTVibration: 415d14d6a1a64bf947fcef6b193915a494431168
+  React-RCTAnimation: f50eac1c9dbea36c4abc69cb24e2da4364374055
+  React-RCTAppDelegate: a5d746fec869d15a8f6eecce60510c18e52135d5
+  React-RCTBlob: e544dc72edc6f277c67e85493b0a405e1993c250
+  React-RCTFabric: 8003ea99830c294857d41469a888b033e5ad91a6
+  React-RCTFBReactNativeSpec: 8a3506041284fdc75da90e6fa40fb9b575414a39
+  React-RCTImage: fb85496986a53d9e11a835124a083b7c7c33f898
+  React-RCTLinking: b8eafcdedaebf981a18396db61d1190f5279ea81
+  React-RCTNetwork: 03573c4fcc73e28f48fea7aea69310b6955a749c
+  React-RCTRuntime: 08d58920b217b2d7715d5da595794e63520cd2d9
+  React-RCTSettings: f9b278b46e5de1ff8b843bb7aefaee721f06572d
+  React-RCTText: 7266943febf3382dac8adce9ba0de95b90c26e9e
+  React-RCTVibration: 27e1952701ec858922062f25a59b0c48e7153151
   React-rendererconsistency: ef8519bdd9931261c6561bfad6506356b8108387
-  React-renderercss: 1aa1bf99fa2ace143eb87d5190fd43609fc1e832
-  React-rendererdebug: 40a4fb3dea21a7ac1759ca0eb6c88a924aecb075
-  React-RuntimeApple: 84fadbb4fe8ca531e15e29a22af05911f17569c6
-  React-RuntimeCore: f4d9af5f16d37e63308cb03b36c89d01e7f68a06
-  React-runtimeexecutor: 4d59410f66af529d04c84c8b152ced07dabc471e
-  React-RuntimeHermes: fd719d8f4d9ce79636fe2e09e94b0ac31b7b263b
-  React-runtimescheduler: 784033620aa5515e2f45a60369eed4d32f9400b8
-  React-timing: a16df9ae98f950396d9ce3abf43cb0cb2f21194c
-  React-utils: b68ee619aef28d8f9b85532d98db0327f7bdf743
-  React-viewtransitionnativemodule: 11fe091101d381451b1542c37b2745900254f096
-  React-webperformancenativemodule: b5d249419f1546663845c82f24de4e18a3180997
-  ReactAppDependencyProvider: dcdd0e1b9559a6d8d8aea05286f4ed085091978e
-  ReactCodegen: afe0d436ee089d7bea6418429d8312b1d23a6801
-  ReactCommon: d5c1bb4427bf51c443de5926aac332c89ddd9363
+  React-renderercss: edc1b0a18b12d681f8edbc779039dc6db32cf7b2
+  React-rendererdebug: 074ec3420f3bab2bea498da65e5a17e9288c90d0
+  React-RuntimeApple: 180682587e82ae4fc525f7d6636ed5db39c1e78c
+  React-RuntimeCore: 991cdb27072f7885750fdad4a70c2b919533e4ef
+  React-runtimeexecutor: bfec6ca5e62c6b2460a4adf0fddce0c4db0a8748
+  React-RuntimeHermes: dcb07afe0f38c1cbaf48b7a1bf4904e867529726
+  React-runtimescheduler: fdf0b71e519e416ad38c76525df43eba8dd78db2
+  React-timing: 7b538f379678210bf30d8541eb4cf007c000c6f3
+  React-utils: a15da1da76aee3dd0ed9f51d62bf1c09be17c221
+  React-viewtransitionnativemodule: 8556c844dcd691ab3fe1b32bbf8f58c8c9a49c75
+  React-webperformancenativemodule: 4d1d0258107fe0cb8ef5c9ac17a6a099785f2995
+  ReactAppDependencyProvider: adf5403892170fbe996fce485a703f25df08db66
+  ReactCodegen: ee39bbc365b4791c9b5183b52c533ebf586e1d8d
+  ReactCommon: 4d01bfb533b93a2103329dfefc74db6a9e272888
+  ReactNativeBottomSheet: 3551d418c1d10cd49e0907d68300374544fb8d00
   ReactNativeDependencies: fa0a54b3f5319ae0e3b9aff32bfee7a424b88e66
-  RNGestureHandler: 953af68599a35f425ea962dda2ee15ee4e3ca719
-  RNPermissions: 82a6127b299cfb3f97c8d36919804a916e58ce26
-  RNReanimated: fcf6a8cdd698fb09a811a8d6c5bcfe36575d965d
-  RNScreens: 62693e770c4b73093c018aa7845b691f5ba9988d
-  RNSVG: 6cae8d4082913be2eb43eaec2a456222c42195ed
-  RNWorklets: 53439575fed8525fb8d1cabcc05a3d4d91e6ffe4
-  VisionCamera: 2d364657571d6b6404830269d05b1de244586a40
-  VisionCameraMLKit: fe1db106ab49d735ac1972c0af27c06778ef8c7e
-  VisionCameraWorklets: 8393549fac54f37a4cf6a7b1088688cf9b309b7f
+  RNGestureHandler: ef19613372e4c87374fe9494862e366d82d1852c
+  RNPermissions: 38d9cf58be74d148123c93d0e0713092e8e59260
+  RNReanimated: 516d842d105966ae05a6a1ad7ad2a0dc1e968d6b
+  RNScreens: 37cece0483decca1c3300bb1c2225c798039b8fc
+  RNSVG: ffe18ba0e8fbad864bf22d6f0060a4ee88ec9bf3
+  RNWorklets: 82a5f27dcf3bb69267ec6ce662a756a4d3f61522
+  VisionCamera: 73a21a8ed0feecd7c579d79ae25eaf8c3e63c767
+  VisionCameraMLKit: c85a989fbaae33532636fdf9cab21b287ddf8a3f
+  VisionCameraWorklets: 0f70d789dfce3d2efc67db7e106e2f4a32bbe72e
   Yoga: 94172d87dd5d83fc929bf1ee53121b5d4490b5f2
 
 PODFILE CHECKSUM: bfa9c28a161369f7b66f55890deec95fe59f1504
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/package.json
+++ b/example/package.json
@@ -10,12 +10,12 @@
     "build:ios": "react-native build-ios --mode Debug --destination \"${IOS_DESTINATION:-generic/platform=iOS Simulator}\""
   },
   "dependencies": {
-    "@gorhom/bottom-sheet": "^5.2.14",
     "@react-native-community/blur": "^4.4.1",
     "@react-native-community/slider": "^5.1.2",
     "@react-navigation/elements": "^2.9.3",
     "@react-navigation/native": "^7.1.26",
     "@react-navigation/native-stack": "^7.9.0",
+    "@swmansion/react-native-bottom-sheet": "0.17.0-next.1",
     "lucide-react-native": "^0.562.0",
     "react": "19.2.3",
     "react-native": "0.86.0",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
+import { BottomSheetProvider } from '@swmansion/react-native-bottom-sheet';
 import { StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -15,13 +15,13 @@ const App = () => (
   <GestureHandlerRootView style={styles.container}>
     <SafeAreaProvider>
       <ThemeProvider>
-        <BottomSheetModalProvider>
+        <BottomSheetProvider>
           <TerminalProvider>
             <PortalProvider>
               <RootNavigator />
             </PortalProvider>
           </TerminalProvider>
-        </BottomSheetModalProvider>
+        </BottomSheetProvider>
       </ThemeProvider>
     </SafeAreaProvider>
   </GestureHandlerRootView>

--- a/example/src/components/ui/CameraControls.tsx
+++ b/example/src/components/ui/CameraControls.tsx
@@ -23,7 +23,7 @@ type CameraControlsProps = {
   onToggleTorch: () => void;
   onToggleFpsGraph: () => void;
   onOpenSettings: () => void;
-  onOpenTerminal: () => void;
+  onToggleTerminal: () => void;
   outputOrientation: SharedValue<Orientation>;
 };
 
@@ -33,7 +33,7 @@ const CameraControls = ({
   onToggleTorch,
   onToggleFpsGraph,
   onOpenSettings,
-  onOpenTerminal,
+  onToggleTerminal,
   outputOrientation,
 }: CameraControlsProps) => {
   const Torch = torch === 'on' ? Zap : ZapOff;
@@ -71,9 +71,9 @@ const CameraControls = ({
         <Gauge size={24} color={theme.colors.icon.primary} />
       </CameraButton>
       <CameraButton
-        onPress={onOpenTerminal}
-        accessibilityLabel="Open terminal"
-        accessibilityHint="Shows the terminal with ML Kit results"
+        onPress={onToggleTerminal}
+        accessibilityLabel="Toggle terminal"
+        accessibilityHint="Shows or hides the terminal with ML Kit results"
         outputOrientation={outputOrientation}
       >
         <Terminal size={24} color={theme.colors.icon.primary} />

--- a/example/src/components/views/TerminalBottomSheet.tsx
+++ b/example/src/components/views/TerminalBottomSheet.tsx
@@ -78,6 +78,7 @@ const TerminalBottomSheet = ({
 
   return (
     <ModalBottomSheet
+      style={styles.sheetHost}
       detents={detents}
       index={index}
       onIndexChange={onIndexChange}
@@ -171,6 +172,10 @@ const styles = StyleSheet.create({
   },
   surface: {
     borderRadius: 15,
+  },
+  sheetHost: {
+    zIndex: 10,
+    elevation: 10,
   },
   handleContainer: {
     alignItems: 'center',

--- a/example/src/components/views/TerminalBottomSheet.tsx
+++ b/example/src/components/views/TerminalBottomSheet.tsx
@@ -1,12 +1,12 @@
-import { BottomSheetFlatList, BottomSheetModal } from '@gorhom/bottom-sheet';
+import { ModalBottomSheet } from '@swmansion/react-native-bottom-sheet';
+import { useCallback, useMemo, useState } from 'react';
 import {
-  forwardRef,
-  useCallback,
-  useMemo,
-  useState,
-  type ComponentProps,
-} from 'react';
-import { Pressable, StyleSheet, View } from 'react-native';
+  FlatList,
+  Pressable,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '../../providers/ThemeProvider';
 import {
@@ -15,31 +15,30 @@ import {
 } from '../../stores/terminalStore';
 import { TerminalEntryRow, Text } from '../ui';
 
-type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+type TerminalBottomSheetProps = {
+  index: number;
+  onIndexChange: (index: number) => void;
+};
 
-type TerminalBottomSheetProps = Optional<
-  ComponentProps<typeof BottomSheetModal>,
-  'children'
->;
-
-const TerminalBottomSheet = forwardRef<
-  BottomSheetModal,
-  TerminalBottomSheetProps
->((props, ref) => {
+const TerminalBottomSheet = ({
+  index,
+  onIndexChange,
+}: TerminalBottomSheetProps) => {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
 
   const entries = useTerminalStore((state) => state.entries);
   const clear = useTerminalStore((state) => state.clear);
 
   const [wrapLines, setWrapLines] = useState(true);
 
-  const snapPoints = useMemo(() => ['25%', '60%', '90%'], []);
+  const detents = useMemo(
+    () => [0, windowHeight * 0.25, windowHeight * 0.6, windowHeight * 0.9],
+    [windowHeight]
+  );
 
-  const handleClose = useCallback(() => {
-    if (!ref || typeof ref === 'function') return;
-    ref.current?.dismiss();
-  }, [ref]);
+  const handleClose = useCallback(() => onIndexChange(0), [onIndexChange]);
 
   const renderItem = useCallback(
     ({ item }: { item: TerminalEntry }) => (
@@ -64,17 +63,37 @@ const TerminalBottomSheet = forwardRef<
     []
   );
 
+  const surface = useMemo(
+    () => (
+      <View
+        style={[
+          StyleSheet.absoluteFill,
+          styles.surface,
+          { backgroundColor: theme.colors.surface },
+        ]}
+      />
+    ),
+    [theme.colors.surface]
+  );
+
   return (
-    <BottomSheetModal
-      ref={ref}
-      snapPoints={snapPoints}
-      enablePanDownToClose
-      containerStyle={styles.modalContainer}
-      topInset={insets.top}
-      handleIndicatorStyle={{ backgroundColor: theme.colors.border }}
-      backgroundStyle={{ backgroundColor: theme.colors.surface }}
-      {...props}
+    <ModalBottomSheet
+      detents={detents}
+      index={index}
+      onIndexChange={onIndexChange}
+      surface={surface}
     >
+      <View style={styles.handleContainer}>
+        <View
+          style={[
+            styles.handleIndicator,
+            {
+              width: windowWidth * 0.075,
+              backgroundColor: theme.colors.border,
+            },
+          ]}
+        />
+      </View>
       <View
         style={[
           styles.header,
@@ -108,7 +127,7 @@ const TerminalBottomSheet = forwardRef<
           </Pressable>
         </View>
       </View>
-      <BottomSheetFlatList
+      <FlatList
         data={entries}
         keyExtractor={(item: TerminalEntry) => item.id}
         renderItem={renderItem}
@@ -121,9 +140,9 @@ const TerminalBottomSheet = forwardRef<
         maxToRenderPerBatch={8}
         ItemSeparatorComponent={ItemSeparatorComponent}
       />
-    </BottomSheetModal>
+    </ModalBottomSheet>
   );
-});
+};
 
 const styles = StyleSheet.create({
   header: {
@@ -150,9 +169,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
   },
-  modalContainer: {
-    zIndex: 10,
-    elevation: 10,
+  surface: {
+    borderRadius: 15,
+  },
+  handleContainer: {
+    alignItems: 'center',
+    paddingVertical: 10,
+  },
+  handleIndicator: {
+    height: 4,
+    borderRadius: 4,
   },
   itemSeparator: {
     height: 12,
@@ -162,7 +188,5 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
 });
-
-TerminalBottomSheet.displayName = 'TerminalBottomSheet';
 
 export { TerminalBottomSheet };

--- a/example/src/providers/TerminalProvider.tsx
+++ b/example/src/providers/TerminalProvider.tsx
@@ -1,15 +1,15 @@
-import type { SNAP_POINT_TYPE } from '@gorhom/bottom-sheet';
-import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import type { ReactNode } from 'react';
 import {
   createContext,
   useCallback,
   useContext,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import { TerminalBottomSheet } from '../components/views';
+
+const CLOSED_INDEX = 0;
+const OPEN_INDEX = 1;
 
 type TerminalContextType = {
   open: () => void;
@@ -24,29 +24,20 @@ type TerminalProviderProps = {
 };
 
 export const TerminalProvider = ({ children }: TerminalProviderProps) => {
-  const modalRef = useRef<BottomSheetModal>(null);
+  const [index, setIndex] = useState(CLOSED_INDEX);
 
-  const [isOpen, setIsOpen] = useState(false);
-
-  const handleChange = useCallback(
-    (index: number, _position: number, _type: SNAP_POINT_TYPE) =>
-      setIsOpen(index >= 0),
-    []
-  );
+  const open = useCallback(() => setIndex(OPEN_INDEX), []);
+  const close = useCallback(() => setIndex(CLOSED_INDEX), []);
 
   const value = useMemo(
-    () => ({
-      open: () => modalRef.current?.present(),
-      close: () => modalRef.current?.dismiss(),
-      isOpen,
-    }),
-    [isOpen]
+    () => ({ open, close, isOpen: index > CLOSED_INDEX }),
+    [open, close, index]
   );
 
   return (
     <TerminalContext.Provider value={value}>
       {children}
-      <TerminalBottomSheet ref={modalRef} onChange={handleChange} />
+      <TerminalBottomSheet index={index} onIndexChange={setIndex} />
     </TerminalContext.Provider>
   );
 };

--- a/example/src/providers/TerminalProvider.tsx
+++ b/example/src/providers/TerminalProvider.tsx
@@ -14,6 +14,7 @@ const OPEN_INDEX = 1;
 type TerminalContextType = {
   open: () => void;
   close: () => void;
+  toggle: () => void;
   isOpen: boolean;
 };
 
@@ -28,10 +29,15 @@ export const TerminalProvider = ({ children }: TerminalProviderProps) => {
 
   const open = useCallback(() => setIndex(OPEN_INDEX), []);
   const close = useCallback(() => setIndex(CLOSED_INDEX), []);
+  const toggle = useCallback(
+    () =>
+      setIndex((prev) => (prev === CLOSED_INDEX ? OPEN_INDEX : CLOSED_INDEX)),
+    []
+  );
 
   const value = useMemo(
-    () => ({ open, close, isOpen: index > CLOSED_INDEX }),
-    [open, close, index]
+    () => ({ open, close, toggle, isOpen: index > CLOSED_INDEX }),
+    [open, close, toggle, index]
   );
 
   return (

--- a/example/src/screens/CameraScreen.tsx
+++ b/example/src/screens/CameraScreen.tsx
@@ -1,12 +1,13 @@
 import {
   StackActions,
+  useFocusEffect,
   useIsFocused,
   useNavigation,
   useRoute,
   type NavigationProp,
   type RouteProp,
 } from '@react-navigation/native';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSharedValue } from 'react-native-reanimated';
 import {
   type CameraRef,
@@ -37,7 +38,7 @@ const DEFAULT_ORIENTATION: Orientation = 'portrait';
 const CameraScreen = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const { params, name } = useRoute<RouteProp<RootStackParamList, 'Camera'>>();
-  const { open: openTerminal } = useTerminal();
+  const { toggle: toggleTerminal, close: closeTerminal } = useTerminal();
 
   const cameraRef = useRef<CameraRef>(null);
 
@@ -76,6 +77,12 @@ const CameraScreen = () => {
     !hasCameraPermission && requestCameraPermission();
   }, [hasCameraPermission, requestCameraPermission]);
 
+  useFocusEffect(
+    useCallback(() => {
+      return () => closeTerminal();
+    }, [closeTerminal])
+  );
+
   if (!hasCameraPermission) return <NoCameraPermissionErrorView />;
   if (!device) return <NoDeviceErrorView />;
   if (!isPluginId(params.id)) return <NoPluginErrorView />;
@@ -98,7 +105,7 @@ const CameraScreen = () => {
         torch={torchState}
         onToggleTorch={toggleTorch}
         onToggleFpsGraph={toggleFpsGraph}
-        onOpenTerminal={openTerminal}
+        onToggleTerminal={toggleTerminal}
         onOpenSettings={openSettings}
         outputOrientation={outputOrientation}
       />

--- a/example/src/screens/ImageScreen.tsx
+++ b/example/src/screens/ImageScreen.tsx
@@ -1,11 +1,12 @@
 import {
   StackActions,
+  useFocusEffect,
   useNavigation,
   useRoute,
   type NavigationProp,
   type RouteProp,
 } from '@react-navigation/native';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { Image, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
@@ -40,9 +41,15 @@ const ImageScreen = () => {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const { open: openTerminal } = useTerminal();
+  const { open: openTerminal, close: closeTerminal } = useTerminal();
 
   const addEntry = useTerminalStore((state) => state.addEntry);
+
+  useFocusEffect(
+    useCallback(() => {
+      return () => closeTerminal();
+    }, [closeTerminal])
+  );
 
   const BOTTOM_OFFSET = insets.bottom + 46;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,40 +2200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gorhom/bottom-sheet@npm:^5.2.14":
-  version: 5.2.14
-  resolution: "@gorhom/bottom-sheet@npm:5.2.14"
-  dependencies:
-    "@gorhom/portal": "npm:1.0.14"
-    invariant: "npm:^2.2.4"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-native": "*"
-    react: "*"
-    react-native: "*"
-    react-native-gesture-handler: ">=2.16.1"
-    react-native-reanimated: "*"
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-native":
-      optional: true
-  checksum: 10c0/744c718aaa4e66989043378932ea31d8ff510cff289b5561115530ff49218af080d28dbe409191b33ab7d87b1cfab4e7c16cfb0015cf2b6917b26c61f033bc05
-  languageName: node
-  linkType: hard
-
-"@gorhom/portal@npm:1.0.14":
-  version: 1.0.14
-  resolution: "@gorhom/portal@npm:1.0.14"
-  dependencies:
-    nanoid: "npm:^3.3.1"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 10c0/86f33afc2ac2656a86a6f3fd1e41565419839576ede2c38333434a93a0a2fe4fb6fc18ab3360579427f2a1fc3b4564b933cc5ae1793a7e2825c93860a00b215f
-  languageName: node
-  linkType: hard
-
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -3717,6 +3683,16 @@ __metadata:
   dependencies:
     "@sinonjs/commons": "npm:^3.0.0"
   checksum: 10c0/2e2fb6cc57f227912814085b7b01fede050cd4746ea8d49a1e44d5a0e56a804663b0340ae2f11af7559ea9bf4d087a11f2f646197a660ea3cb04e19efc04aa63
+  languageName: node
+  linkType: hard
+
+"@swmansion/react-native-bottom-sheet@npm:0.17.0-next.1":
+  version: 0.17.0-next.1
+  resolution: "@swmansion/react-native-bottom-sheet@npm:0.17.0-next.1"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-native: ">=0.76.0"
+  checksum: 10c0/8ea6751efc9cb2c11ede4f90d2378c95270dc707c08b9718b11bf28c1a4e5b09d33887801e682a7273c9cb1ce8675daba7cf0da0e6ac5f944faf259326d528a9
   languageName: node
   linkType: hard
 
@@ -9808,7 +9784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.1, nanoid@npm:^3.3.11":
+"nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -11007,7 +10983,6 @@ __metadata:
     "@babel/core": "npm:^7.25.2"
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/runtime": "npm:^7.25.0"
-    "@gorhom/bottom-sheet": "npm:^5.2.14"
     "@react-native-community/blur": "npm:^4.4.1"
     "@react-native-community/cli": "npm:20.1.0"
     "@react-native-community/cli-platform-android": "npm:20.1.0"
@@ -11019,6 +10994,7 @@ __metadata:
     "@react-navigation/elements": "npm:^2.9.3"
     "@react-navigation/native": "npm:^7.1.26"
     "@react-navigation/native-stack": "npm:^7.9.0"
+    "@swmansion/react-native-bottom-sheet": "npm:0.17.0-next.1"
     "@types/react": "npm:^19.2.0"
     lucide-react-native: "npm:^0.562.0"
     react: "npm:19.2.3"


### PR DESCRIPTION
## Summary

- Swaps the example app's Terminal bottom sheet from `@gorhom/bottom-sheet` to `@swmansion/react-native-bottom-sheet@0.17.0-next.1`.
- Targets the root cause suspected in the reverted "Terminal bottom-sheet toggle + close-on-focus-loss" attempt: the new library's sheet host, gestures, snapping, and scroll negotiation all run in native code and depend on neither `react-native-gesture-handler` nor `react-native-reanimated`, unlike `@gorhom/bottom-sheet` (which was never validated against our RNGH v3 combo before we hit an "sheet won't open" bug from it).
- `TerminalProvider` moves from an imperative `BottomSheetModal` ref (`present()`/`dismiss()`) to a controlled `index` state (`0` closed, `1` open), and `open`/`close` are now `useCallback`-stabilized (previously recreated on every `isOpen` change).
- `TerminalBottomSheet` swaps `ModalBottomSheet`/`FlatList` in for `BottomSheetModal`/`BottomSheetFlatList`, and hand-builds the handle pill + rounded background the old library provided by default, matching the previous visual styling (same colors, same 15pt corner radius, same 7.5%-width handle indicator).
- Percentage snap points (`25%`/`60%`/`90%`) become pixel detents derived from `useWindowDimensions`, with `0` as the explicit closed detent (replaces `enablePanDownToClose`/portal unmount).

### Follow-up fixes from on-device testing

- **Z-order regression, fixed**: the initial swap dropped `@gorhom`'s `containerStyle` `zIndex`/`elevation`, assumed to be gorhom-specific boilerplate. It wasn't — it's what kept the sheet above `PortalProvider`'s `zIndex: 1, elevation: 1` host view (used by `PortalSegmentedToggle`, the Camera/Image switcher). Restored via `ModalBottomSheet`'s `style` prop (`zIndex: 10, elevation: 10`), the new library's equivalent knob.
- **Toggle and close-on-blur, now delivered** (previously flagged as deliberately out of scope to keep the swap small — now folded in since we were already here and it's cheap with the controlled-index model):
  - `TerminalProvider` exposes a stabilized `toggle()` alongside `open`/`close`.
  - `CameraControls`' icon-only terminal button now toggles instead of only ever opening (renamed `onOpenTerminal` -> `onToggleTerminal` to match `onToggleTorch`/`onToggleFpsGraph`). `ImageScreen`'s two explicit "open" call sites (auto-open after processing, "Open Terminal" button) are unchanged — toggling those would be the wrong affordance for an explicit open action.
  - `CameraScreen` and `ImageScreen` close the terminal via `useFocusEffect`'s cleanup on blur (covers navigating to Settings/Home, and switching between Camera/Image through `PortalSegmentedToggle`'s stack replace) — instead of the previous global `NavigationContainer.onStateChange` attempt that broke opening the sheet entirely.

**Caveat:** `@swmansion/react-native-bottom-sheet` is early (`0.17.0-next.1`, published under the `software-mansion-labs` incubation org, not a stable `1.x`). Pinned to the exact version (no `^` range) rather than tracking `-next` prereleases automatically.

## Test plan

- [x] `yarn typecheck` / `yarn lint` / `yarn test --runInBand` all green
- [x] `pod install` succeeded, `ReactNativeBottomSheet 0.17.0-next.1` linked
- [x] `npx react-native config` confirms Android autolinking resolved (Fabric component descriptors `BottomSheetViewComponentDescriptor` / `BottomSheetSurfaceViewComponentDescriptor`)
- [x] iOS on-device: confirmed working (initial swap), z-order regression found and fixed (this round)
- [ ] iOS on-device retest: sheet renders above `PortalSegmentedToggle`, toggle button opens/closes, close-on-blur works navigating to Settings and switching Camera/Image
- [ ] Android on-device: same checks as above (not yet tested on this platform)
- [ ] Visual check: handle pill, rounded corners, colors match previous `@gorhom` styling (no backdrop dimming, same as before)