### PR TITLE
fix: drop peer/build dependencies the library doesn't actually need

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,37 @@ A [React Native Vision Camera](https://github.com/mrousavy/react-native-vision-c
 - iOS 12+ and Android SDK 21+
 - [react-native-vision-camera](https://www.npmjs.com/package/react-native-vision-camera) `>=5` (Nitro-based v5, not v4)
 - [react-native-nitro-modules](https://www.npmjs.com/package/react-native-nitro-modules)
-- [react-native-nitro-image](https://www.npmjs.com/package/react-native-nitro-image)
-- [react-native-vision-camera-worklets](https://www.npmjs.com/package/react-native-vision-camera-worklets)
-- [react-native-worklets](https://www.npmjs.com/package/react-native-worklets)
 
-Install Vision Camera and its Nitro/worklets dependencies:
+Install Vision Camera and its Nitro dependency:
 
 ```sh
-npm i react-native-vision-camera react-native-nitro-modules react-native-nitro-image react-native-vision-camera-worklets react-native-worklets
+npm i react-native-vision-camera react-native-nitro-modules
 cd ios && pod install
 ```
 
-Add the Babel plugin in `babel.config.js`:
+> `react-native-vision-camera` has its own peer dependencies (currently
+> `react-native-nitro-image`); follow the prompts from your package manager
+> or the [Vision Camera docs](https://visioncamera.margelo.com/docs) to
+> install those too.
+
+If you're using the **live-frame hooks** (`useTextRecognition`,
+`useBarcodeScanning`), you also need Vision Camera's frame processor
+dependencies, since those hooks run inside a `useFrameOutput` worklet:
+
+```sh
+npm i react-native-vision-camera-worklets react-native-worklets
+```
 
 ```js
+// babel.config.js
 module.exports = {
   plugins: [['react-native-worklets/plugin']],
 };
 ```
+
+The **static-image APIs** (`processImageTextRecognition`,
+`processImageBarcodeScanning`) don't use frame processors and don't need
+Vision Camera, Worklets, or a camera at all.
 
 > For Expo, follow the Vision Camera guide: [visioncamera.margelo.com/docs](https://visioncamera.margelo.com/docs)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -182,7 +182,6 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   api project(":react-native-vision-camera")
-  implementation project(":react-native-nitro-image")
   implementation project(":react-native-nitro-modules")
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.camera:camera-core:1.5.2"

--- a/package.json
+++ b/package.json
@@ -103,11 +103,8 @@
     "react": "19.2.3",
     "react-native": "0.86.0",
     "react-native-builder-bob": "^0.40.13",
-    "react-native-nitro-image": "0.15.1",
     "react-native-nitro-modules": "0.36.1",
     "react-native-vision-camera": "^5.1.0",
-    "react-native-vision-camera-worklets": "^5.1.0",
-    "react-native-worklets": "0.10.2",
     "release-it": "^19.0.4",
     "turbo": "^2.5.6",
     "typescript": "^5.9.2"
@@ -115,11 +112,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-nitro-image": "*",
     "react-native-nitro-modules": "*",
-    "react-native-vision-camera": ">=5",
-    "react-native-vision-camera-worklets": "*",
-    "react-native-worklets": "*"
+    "react-native-vision-camera": ">=5"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11045,22 +11045,16 @@ __metadata:
     react: "npm:19.2.3"
     react-native: "npm:0.86.0"
     react-native-builder-bob: "npm:^0.40.13"
-    react-native-nitro-image: "npm:0.15.1"
     react-native-nitro-modules: "npm:0.36.1"
     react-native-vision-camera: "npm:^5.1.0"
-    react-native-vision-camera-worklets: "npm:^5.1.0"
-    react-native-worklets: "npm:0.10.2"
     release-it: "npm:^19.0.4"
     turbo: "npm:^2.5.6"
     typescript: "npm:^5.9.2"
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-nitro-image: "*"
     react-native-nitro-modules: "*"
     react-native-vision-camera: ">=5"
-    react-native-vision-camera-worklets: "*"
-    react-native-worklets: "*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Prompted by a question about whether `react-native-nitro-image`, `react-native-vision-camera-worklets`, and `react-native-worklets` are genuinely required by this library, or only by the example app.

Traced every actual import in `src/`, `android/`, and `ios/`:

- **`react-native-vision-camera-worklets` / `react-native-worklets`**: not imported anywhere in this library's own code (only the `'worklet'` Babel-plugin string directive appears, in JSDoc/hook comments — not an import). They're an app-level opt-in required to use `react-native-vision-camera`'s frame-processor feature at all — a requirement flowing from Vision Camera's own API contract, not from this library. Confirmed Vision Camera itself doesn't declare them as peer dependencies either. Declaring them as required peer deps also wrongly implied the **static-image APIs** (`processImageTextRecognition`/`processImageBarcodeScanning`, which go through the classic native bridge and never touch Vision Camera) need a camera at all.
- **`react-native-nitro-image`**: also unused anywhere in this library's code (`src/`, `android/src`, `ios/`, `nitro.json`, and the podspec all confirmed clean). It *is* a hard transitive peer/pod dependency of `react-native-vision-camera` itself (its own `package.json` peerDependencies and podspec both declare it) — verified empirically: `yarn install` on this branch still surfaces `react-native-vision-camera-mlkit doesn't provide react-native-nitro-image ... requested by react-native-vision-camera` without this library redeclaring it.
- Removed the matching unused `implementation project(":react-native-nitro-image")` line from `android/build.gradle` — not referenced by any Kotlin source or generated Nitrogen output.

README's Requirements/install section rewritten to reflect the real shape: `react-native-vision-camera` + `react-native-nitro-modules` for the base install, `react-native-vision-camera-worklets` + `react-native-worklets` (+ Babel plugin) only if using the live-frame hooks, with an explicit callout that the static-image APIs need neither.

This is a relaxation, not a breaking change — existing consumers with those packages installed are unaffected; new consumers who only want the static-image APIs no longer get nagged for camera/worklet packages they'll never use.

## Test plan

- [x] `yarn install` — resolves cleanly, still surfaces the expected transitive `react-native-nitro-image` peer warning from `react-native-vision-camera` itself
- [x] `yarn typecheck` / `yarn lint` / `yarn test --runInBand` all green
- [x] `yarn prepare` (bob build) succeeds