### PR TITLE
docs: fix inaccurate claims and gaps across README/CONTRIBUTING/docs and npm metadata

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,9 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at [issues](https://github.com/pedrol2b/react-native-vision-camera-mlkit/issues).
+reported to the community leaders responsible for enforcement by emailing
+**pedrolbb.e@gmail.com**. Please do not report Code of Conduct violations via
+public GitHub issues, since those reports are not private.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,16 @@ If you want to use Android Studio or XCode to edit the native code, you can open
 
 To edit the Java or Kotlin files, open `android` in Android studio and find the source files at `react-native-vision-camera-mlkit` under `Android`.
 
+> If you hit an iOS build failure in Pods referencing `fmt/include/fmt/base.h` or `FMT_USE_CONSTEVAL` on Xcode 26.4, see [docs/xcode-26.4-fmt-consteval-workaround.md](docs/xcode-26.4-fmt-consteval-workaround.md).
+
+### Working with the Nitro spec
+
+This library is a [Nitro Module](https://nitro.margelo.com). The native interface is defined in `src/specs/*.nitro.ts`. If you change a `.nitro.ts` spec file, regenerate the generated Swift/Kotlin/C++ bindings before rebuilding the example app:
+
+```sh
+yarn specs
+```
+
 You can use various commands from the root directory to work with the project.
 
 To start the packager, `cd` into the `example` directory, `cd example`, and then:
@@ -73,11 +83,14 @@ We follow the [conventional commits specification](https://www.conventionalcommi
 - `fix`: bug fixes, e.g. fix crash due to deprecated method.
 - `feat`: new features, e.g. add new method to the module.
 - `refactor`: code refactor, e.g. migrate from class components to hooks.
-- `docs`: changes into documentation, e.g. add usage example for the module..
+- `docs`: changes into documentation, e.g. add usage example for the module.
 - `test`: adding or updating tests, e.g. add integration tests using detox.
-- `chore`: tooling changes, e.g. change CI config.
+- `chore`: tooling changes, e.g. change dependency versions.
+- `perf`: performance improvements, e.g. optimize a hot path.
+- `ci`: CI/CD pipeline changes, e.g. update a GitHub Actions workflow.
+- `build`: build system or external dependency changes, e.g. bump the RN version.
 
-Our pre-commit hooks verify that your commit message matches this format when committing.
+Our `commit-msg` hook (via commitlint) verifies that your commit message matches this format when committing.
 
 ### Linting and tests
 
@@ -85,7 +98,7 @@ Our pre-commit hooks verify that your commit message matches this format when co
 
 We use [TypeScript](https://www.typescriptlang.org/) for type checking, [ESLint](https://eslint.org/) with [Prettier](https://prettier.io/) for linting and formatting the code, and [Jest](https://jestjs.io/) for testing.
 
-Our pre-commit hooks verify that the linter and tests pass when committing.
+Our `pre-commit` hook (via lefthook) runs ESLint and a TypeScript check on staged files. Tests aren't run automatically on commit, so run `yarn test` yourself before opening a pull request.
 
 ### Scripts
 
@@ -95,9 +108,12 @@ The `package.json` file contains various scripts for common tasks:
 - `yarn typecheck`: type-check files with TypeScript.
 - `yarn lint`: lint files with ESLint.
 - `yarn test`: run unit tests with Jest.
+- `yarn specs`: regenerate native bindings from the Nitro spec (`src/specs/*.nitro.ts`) with nitrogen.
+- `yarn clean`: remove build artifacts for the library and the example app (Android/iOS).
 - `yarn start`: start the Metro server for the example app.
 - `yarn android`: run the example app on Android.
 - `yarn ios`: run the example app on iOS.
+- `yarn prepare`: build the library for publishing with `react-native-builder-bob` (runs automatically as Yarn's `prepare` lifecycle hook after install; rarely needed manually).
 
 ### Sending a pull request
 
@@ -108,5 +124,4 @@ When you're sending a pull request:
 - Prefer small pull requests focused on one change.
 - Verify that linters and tests are passing.
 - Review the documentation to make sure it looks good.
-- Follow the pull request template when opening a pull request.
-- For pull requests that change the API or implementation, discuss with maintainers first by opening an issue.
+- For pull requests that change the API or implementation, discuss with maintainers first by opening an issue (see the [issue templates](.github/ISSUE_TEMPLATE) for bug reports, build errors, and feature requests).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![MIT License][license-shield]][license-url]
 [![NPM Version][npm-version-shield]][npm-version-url]
 
-A [React Native Vision Camera](https://github.com/mrousavy/react-native-vision-camera) plugin that exposes high-performance [Google ML Kit](https://developers.google.com/ml-kit) [frame output](https://visioncamera.margelo.com/docs/frame-output) features such as text recognition (OCR), face detection, barcode scanning, pose detection, and more.
+A [React Native Vision Camera](https://github.com/mrousavy/react-native-vision-camera) plugin that exposes high-performance [Google ML Kit](https://developers.google.com/ml-kit) [frame output](https://visioncamera.margelo.com/docs/frame-output) features. Ships today: text recognition (OCR) and barcode scanning. Face detection, pose detection, and other ML Kit vision features are planned — see the [roadmap](#google-ml-kit-vision-features-roadmap) below.
 
 > The example app is intentionally heavy and demo-focused. For integration details, follow the documentation below.
 
@@ -400,12 +400,18 @@ const { textRecognition } = useTextRecognition({
 
 iOS camera sensors are fixed in landscape orientation. The frame buffer stays landscape-shaped even when the UI rotates, so ML Kit needs an explicit orientation hint to rotate text correctly. On iOS, pass `outputOrientation` to `textRecognition(frame, { outputOrientation })` so ML Kit can map the buffer to upright text. Android handles rotation automatically.
 
+## Troubleshooting
+
 ### ⚠️ iOS Simulator (Apple Silicon) – Heads-up
 
 On Apple Silicon Macs, building for the **iOS Simulator (arm64)** may fail after installing this package.
 
 This is a **known limitation of Google ML Kit**, which does not currently ship an `arm64-simulator` slice for some iOS frameworks.
 The library works correctly on **physical iOS devices** and on the **iOS Simulator when running under Rosetta**.
+
+### Xcode 26.4 Build Failures (fmt / consteval)
+
+If your iOS build fails in Pods with errors referencing `fmt/include/fmt/base.h` or `FMT_USE_CONSTEVAL` after updating to Xcode 26.4, see [docs/xcode-26.4-fmt-consteval-workaround.md](docs/xcode-26.4-fmt-consteval-workaround.md) for the root cause and a `post_install` Podfile patch. This is a React Native / Xcode toolchain issue, not specific to this library.
 
 ## Google ML Kit Vision Features Roadmap
 

--- a/docs/barcode-scanning.md
+++ b/docs/barcode-scanning.md
@@ -104,10 +104,10 @@ const result = await processImageBarcodeScanning(imageUri, {
 
 Each barcode includes:
 
-- geometry: `bounds`, `corners`
-- identity: `format`, `formatName`, `valueType`, `valueTypeName`
+- geometry: `bounds`, `corners` (optional — may be absent for potential barcodes)
+- identity: `format`, `formatName`, `valueType`, `valueTypeName` — `format`/`valueType` are the raw ML Kit numeric codes; the `*Name` variants are the human-readable string equivalents and are what you should match against in application code
 - raw payload: `rawValue`, `displayValue`, `rawBytes`
-- `isPotential` (true for potential/undecoded barcode candidates)
+- `isPotential` (true for potential/undecoded barcode candidates; when `true`, `rawValue`/`rawBytes` may be `null`)
 - parsed payload: `value?: BarcodeParsedValue`
 
 ### Parsed value typing

--- a/docs/text-recognition.md
+++ b/docs/text-recognition.md
@@ -11,6 +11,7 @@ import {
   type TextRecognitionOptions,
   type TextRecognitionArguments,
   type TextRecognitionImageOptions,
+  type TextRecognitionResult,
 } from 'react-native-vision-camera-mlkit';
 ```
 
@@ -77,13 +78,21 @@ const result = await processImageTextRecognition(imageUri, {
 
 ## Result shape
 
-Text recognition returns:
+`TextRecognitionResult` is a nested hierarchy: text → blocks → lines → elements
+(→ symbols on Android). Every level carries its own `bounds`/`corners`
+geometry, already mapped back to full source coordinates (see
+[Region of Interest](../README.md#region-of-interest)).
 
-- top-level text content
-- blocks
-- lines
-- elements
-- geometry (`bounds`, `corners`) with transformed coordinates
+- `text: string` — the full recognized text.
+- `blocks: TextBlock[]`
+  - `text: string`, `bounds`, `corners`, `languages: string[]` (ISO 639-1/639-2)
+  - `lines: TextLine[]`
+    - `text: string`, `bounds`, `corners`, `languages: string[]`
+    - `confidence: number | null`, `angle: number | null` (Android only)
+    - `elements: TextElement[]`
+      - `text: string`, `bounds`, `corners`, `languages: string[]`
+      - `confidence: number | null`, `angle: number | null` (Android only)
+      - `symbols: TextSymbol[]` (Android only) — `text`, `bounds`, `corners`, `confidence`, `angle`
 
 ## iOS orientation note
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-vision-camera-mlkit",
   "version": "2.0.0",
-  "description": "A powerful React Native Vision Camera plugin delivering high-performance Google ML Kit frame processor features—including text recognition (OCR), face detection, barcode scanning, pose detection, and more. Seamlessly bridges native ML Kit capabilities for real-time, on-device computer vision in your React Native apps.",
+  "description": "A React Native Vision Camera (v5, Nitro-based) plugin for Google ML Kit vision features. Ships text recognition (OCR) and barcode scanning today, for real-time frame processing and static images, with more ML Kit vision features (face detection, pose detection, and others) on the roadmap.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",
   "exports": {
@@ -61,9 +61,9 @@
     "image-processing",
     "camera",
     "text-detection",
-    "face-detection",
+    "text-recognition",
     "barcode-scanner",
-    "pose-detection"
+    "barcode-scanning"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Full audit of README.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, LICENSE, SECURITY.md, docs/*.md, and package.json's `description`/`keywords`.

- **npm metadata overselling unimplemented features (highest-value fix)**: `package.json`'s `description` and `keywords`, and README's intro sentence, listed face detection and pose detection alongside text recognition/barcode scanning as if all were shipped. Only text recognition v2 and barcode scanning exist in `src/features/` — everything else is Phase 3 roadmap, not implemented. Rewrote both to state what ships today and frame the rest as roadmap (linking the roadmap table); swapped `face-detection`/`pose-detection` keywords for `text-recognition`/`barcode-scanning`.
- **`docs/text-recognition.md`**: "Result shape" only named nesting levels with no fields. Expanded to the full block→line→element→symbol field breakdown, verified field-by-field against `src/features/text-recognition/types.ts` (confidence/angle Android-only on line/element, required on symbol, etc.).
- **`docs/barcode-scanning.md`**: clarified `format`/`valueType` are raw ML Kit numeric codes vs. the `*Name` string equivalents apps should actually match against, and that `bounds`/`corners`/`rawValue`/`rawBytes` can be absent/null for potential barcodes — verified against `src/features/barcode-scanning/types.ts`.
- **README.md**: fixed the same overselling problem in the intro; also fixed a structural issue where the Apple Silicon simulator note was nested under an unrelated heading, and `docs/xcode-26.4-fmt-consteval-workaround.md` was linked from nowhere. Both now live under a new "Troubleshooting" section. Left the Requirements/Installation (peer-dependency) section untouched — verified accurate per #15.
- **CONTRIBUTING.md**: fixed inaccurate claims (pre-commit hooks only run eslint+tsc, not tests — verified against `lefthook.yml`; commit-message check is a separate `commit-msg` hook). Removed a reference to a nonexistent PR template. Added a "Working with the Nitro spec" section (`yarn specs` regeneration was undocumented) and the missing `specs`/`clean`/`prepare` scripts. Added `perf`/`ci`/`build` commit types (used in actual repo history, missing from the documented list). Linked the previously-orphaned Xcode 26.4 workaround doc.
- **CODE_OF_CONDUCT.md**: conduct-violation reports pointed at the public issue tracker, which isn't private/confidential (inconsistent with SECURITY.md's own private-reporting stance for security issues). Switched to direct email contact (already public in `package.json`'s `author` field).
- **LICENSE, SECURITY.md, docs/xcode-26.4-fmt-consteval-workaround.md**: reviewed, no concrete inaccuracies found, left as-is.

## Test plan

- [x] `yarn lint` / `yarn typecheck` / `yarn test` all green
- [x] Cross-checked every technical claim added to docs/text-recognition.md and docs/barcode-scanning.md against the actual TypeScript types
- [x] Confirmed README's peer-dependency Requirements section (from #15) was not reverted