### PR TITLE
feat: add Expo config plugin for selective ML Kit dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ The **static-image APIs** (`processImageTextRecognition`,
 `processImageBarcodeScanning`) don't use frame processors and don't need
 Vision Camera, Worklets, or a camera at all.
 
-> For Expo, follow the Vision Camera guide: [visioncamera.margelo.com/docs](https://visioncamera.margelo.com/docs)
+> For Expo, follow the Vision Camera guide for camera permissions/setup:
+> [visioncamera.margelo.com/docs](https://visioncamera.margelo.com/docs).
+> This library's own Expo config plugin (selective ML Kit dependencies) is
+> documented below.
 
 ## Installation
 
@@ -123,6 +126,36 @@ $VisionCameraMLKit = {
 ```
 
 Android-only keys: `faceMeshDetection`, `subjectSegmentation`, `documentScanner`.
+
+### Expo (config plugin)
+
+If you're using an Expo prebuild workflow (`expo prebuild`, EAS Build, or a
+custom dev client), a config plugin mirrors the same selective ML Kit flags
+into the generated `android/build.gradle` and `ios/Podfile` automatically, so
+you don't have to hand-edit native config. Add it to your `app.json`/
+`app.config.js` `plugins` array with the same keys as above:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-vision-camera-mlkit",
+        {
+          "textRecognition": true,
+          "barcodeScanning": true,
+          "faceDetection": false
+        }
+      ]
+    ]
+  }
+}
+```
+
+Any key you omit keeps the library's own default (see the Android/iOS
+sections above). Passing an unrecognized key throws at prebuild time instead
+of silently being ignored. Requires `@expo/config-plugins` (already a
+dependency of `expo` itself, so Expo projects have it for free).
 
 ## Usage
 

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "files": [
@@ -21,6 +22,8 @@
     "nitrogen",
     "nitro.json",
     "*.podspec",
+    "app.plugin.js",
+    "plugin",
     "react-native.config.js",
     "!ios/build",
     "!android/build",
@@ -84,6 +87,7 @@
     "@eslint/compat": "^1.3.2",
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.35.0",
+    "@expo/config-plugins": "57.0.6",
     "@react-native-community/cli": "20.1.0",
     "@react-native/babel-preset": "0.86.0",
     "@react-native/eslint-config": "^0.86.0",
@@ -110,10 +114,16 @@
     "typescript": "^5.9.2"
   },
   "peerDependencies": {
+    "@expo/config-plugins": "^57.0.0",
     "react": "*",
     "react-native": "*",
     "react-native-nitro-modules": "*",
     "react-native-vision-camera": ">=5"
+  },
+  "peerDependenciesMeta": {
+    "@expo/config-plugins": {
+      "optional": true
+    }
   },
   "workspaces": [
     "example"

--- a/plugin/__tests__/mlkitConfig.test.js
+++ b/plugin/__tests__/mlkitConfig.test.js
@@ -1,0 +1,39 @@
+const { parseMLKitConfig, MLKIT_FEATURE_KEYS } = require('../mlkitConfig');
+
+describe('parseMLKitConfig', () => {
+  test('keeps only recognized keys, coerced to booleans', () => {
+    const result = parseMLKitConfig({
+      textRecognition: true,
+      barcodeScanning: 1,
+      faceDetection: false,
+    });
+
+    expect(result).toEqual({
+      textRecognition: true,
+      barcodeScanning: true,
+      faceDetection: false,
+    });
+  });
+
+  test('omits keys the caller did not set', () => {
+    const result = parseMLKitConfig({ textRecognition: true });
+    expect(Object.keys(result)).toEqual(['textRecognition']);
+  });
+
+  test('defaults to an empty config when no props are given', () => {
+    expect(parseMLKitConfig()).toEqual({});
+  });
+
+  test('throws on unknown option names', () => {
+    expect(() => parseMLKitConfig({ faceDeteciton: true })).toThrow(
+      /unknown option\(s\) "faceDeteciton"/
+    );
+  });
+
+  test('every documented feature key round-trips', () => {
+    const allTrue = Object.fromEntries(
+      MLKIT_FEATURE_KEYS.map((k) => [k, true])
+    );
+    expect(parseMLKitConfig(allTrue)).toEqual(allTrue);
+  });
+});

--- a/plugin/__tests__/withAndroid.test.js
+++ b/plugin/__tests__/withAndroid.test.js
@@ -1,0 +1,54 @@
+const { insertAndroidConfig } = require('../withAndroid');
+
+const BASE_GRADLE = `buildscript {\n  ext {\n    kotlinVersion = "1.9.0"\n  }\n}\n\napply plugin: "com.android.application"\n`;
+
+describe('insertAndroidConfig', () => {
+  test('prepends the ext block with the given config', () => {
+    const result = insertAndroidConfig(
+      BASE_GRADLE,
+      { textRecognition: true, faceDetection: false },
+      { language: 'groovy' }
+    );
+
+    expect(result).toContain('ext["react-native-vision-camera-mlkit"] = [');
+    expect(result).toContain('textRecognition: true,');
+    expect(result).toContain('faceDetection: false,');
+    expect(
+      result.indexOf('ext["react-native-vision-camera-mlkit"]')
+    ).toBeLessThan(result.indexOf('buildscript'));
+  });
+
+  test('is idempotent - running twice does not duplicate the block', () => {
+    const once = insertAndroidConfig(
+      BASE_GRADLE,
+      { textRecognition: true },
+      {
+        language: 'groovy',
+      }
+    );
+    const twice = insertAndroidConfig(
+      once,
+      { textRecognition: true },
+      {
+        language: 'groovy',
+      }
+    );
+
+    expect(twice).toBe(once);
+    expect(
+      once.split(
+        'react-native-vision-camera-mlkit selective ML Kit dependencies'
+      ).length - 1
+    ).toBe(1);
+  });
+
+  test('throws for Kotlin DSL build.gradle.kts', () => {
+    expect(() =>
+      insertAndroidConfig(
+        BASE_GRADLE,
+        { textRecognition: true },
+        { language: 'kt' }
+      )
+    ).toThrow(/Kotlin DSL/);
+  });
+});

--- a/plugin/__tests__/withIOS.test.js
+++ b/plugin/__tests__/withIOS.test.js
@@ -1,0 +1,43 @@
+const { insertIOSConfig } = require('../withIOS');
+
+const BASE_PODFILE = `require File.join(File.dirname(\`node --print "require.resolve('expo/package.json')"\`), "scripts/autolinking")\n\nplatform :ios, '15.1'\n\ntarget 'ExampleApp' do\n  use_expo_modules!\nend\n`;
+
+describe('insertIOSConfig', () => {
+  test('inserts the hash before the target block, dropping Android-only keys', () => {
+    const result = insertIOSConfig(BASE_PODFILE, {
+      textRecognition: true,
+      faceMeshDetection: true,
+      subjectSegmentation: true,
+      documentScanner: true,
+      barcodeScanning: false,
+    });
+
+    expect(result).toContain('$VisionCameraMLKit = {');
+    expect(result).toContain("'textRecognition' => true,");
+    expect(result).toContain("'barcodeScanning' => false,");
+    expect(result).not.toContain('faceMeshDetection');
+    expect(result).not.toContain('subjectSegmentation');
+    expect(result).not.toContain('documentScanner');
+    expect(result.indexOf('$VisionCameraMLKit')).toBeLessThan(
+      result.indexOf("target 'ExampleApp'")
+    );
+  });
+
+  test('is idempotent - running twice does not duplicate the block', () => {
+    const once = insertIOSConfig(BASE_PODFILE, { textRecognition: true });
+    const twice = insertIOSConfig(once, { textRecognition: true });
+
+    expect(twice).toBe(once);
+    expect(
+      once.split(
+        'react-native-vision-camera-mlkit selective ML Kit dependencies'
+      ).length - 1
+    ).toBe(1);
+  });
+
+  test('throws when no target block is found', () => {
+    expect(() => insertIOSConfig("platform :ios, '15.1'\n", {})).toThrow(
+      /could not find a `target` block/
+    );
+  });
+});

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,0 +1,22 @@
+const { createRunOncePlugin } = require('@expo/config-plugins');
+const { name, version } = require('../package.json');
+const { parseMLKitConfig } = require('./mlkitConfig');
+const { withVisionCameraMLKitAndroid } = require('./withAndroid');
+const { withVisionCameraMLKitIOS } = require('./withIOS');
+
+/**
+ * Expo config plugin mirroring this library's selective ML Kit dependency
+ * flags (see README "ML Kit Models Installation (Selective)") into the
+ * generated `android/build.gradle` and `ios/Podfile` during `expo prebuild`,
+ * so Expo users don't have to hand-edit native config.
+ * @throws {Error} If `props` contains an option outside the documented
+ * ML Kit feature flags.
+ */
+const withVisionCameraMLKit = (config, props = {}) => {
+  const mlkitConfig = parseMLKitConfig(props);
+  config = withVisionCameraMLKitAndroid(config, mlkitConfig);
+  config = withVisionCameraMLKitIOS(config, mlkitConfig);
+  return config;
+};
+
+module.exports = createRunOncePlugin(withVisionCameraMLKit, name, version);

--- a/plugin/mlkitConfig.js
+++ b/plugin/mlkitConfig.js
@@ -1,0 +1,57 @@
+/**
+ * Shared feature-flag list for the selective ML Kit dependency config,
+ * mirroring the Android `rootProject.ext["react-native-vision-camera-mlkit"]`
+ * and iOS `$VisionCameraMLKit` keys documented in the README.
+ */
+const MLKIT_FEATURE_KEYS = [
+  'textRecognition',
+  'textRecognitionChinese',
+  'textRecognitionDevanagari',
+  'textRecognitionJapanese',
+  'textRecognitionKorean',
+  'faceDetection',
+  'faceMeshDetection',
+  'poseDetection',
+  'poseDetectionAccurate',
+  'selfieSegmentation',
+  'subjectSegmentation',
+  'documentScanner',
+  'barcodeScanning',
+  'imageLabeling',
+  'objectDetection',
+  'digitalInkRecognition',
+];
+
+/** Keys with no iOS ML Kit equivalent - dropped before writing the Podfile hash. */
+const ANDROID_ONLY_KEYS = new Set([
+  'faceMeshDetection',
+  'subjectSegmentation',
+  'documentScanner',
+]);
+
+/**
+ * Validates and normalizes the plugin's `props` into a flat `{ key: boolean }`
+ * map, throwing on unknown keys instead of silently ignoring typos.
+ * @throws {Error} If `props` contains a key outside {@link MLKIT_FEATURE_KEYS}.
+ */
+const parseMLKitConfig = (props = {}) => {
+  const unknownKeys = Object.keys(props).filter(
+    (key) => !MLKIT_FEATURE_KEYS.includes(key)
+  );
+
+  if (unknownKeys.length > 0) {
+    throw new Error(
+      `react-native-vision-camera-mlkit config plugin: unknown option(s) ${unknownKeys
+        .map((key) => `"${key}"`)
+        .join(', ')}. Valid options: ${MLKIT_FEATURE_KEYS.join(', ')}.`
+    );
+  }
+
+  const config = {};
+  for (const key of MLKIT_FEATURE_KEYS) {
+    if (props[key] !== undefined) config[key] = Boolean(props[key]);
+  }
+  return config;
+};
+
+module.exports = { MLKIT_FEATURE_KEYS, ANDROID_ONLY_KEYS, parseMLKitConfig };

--- a/plugin/withAndroid.js
+++ b/plugin/withAndroid.js
@@ -1,0 +1,54 @@
+const { withProjectBuildGradle } = require('@expo/config-plugins');
+
+const MARKER =
+  '// react-native-vision-camera-mlkit selective ML Kit dependencies';
+
+/**
+ * Renders `mlkitConfig` as the Groovy block consumers are otherwise told to
+ * hand-write at the top of `android/build.gradle` (see README "ML Kit Models
+ * Installation (Selective)").
+ */
+const toGroovyBlock = (mlkitConfig) => {
+  const entries = Object.entries(mlkitConfig)
+    .map(([key, value]) => `    ${key}: ${value},`)
+    .join('\n');
+
+  return `${MARKER}\next["react-native-vision-camera-mlkit"] = [\n  mlkit: [\n${entries}\n  ]\n]\n`;
+};
+
+/**
+ * Prepends the selective ML Kit dependency block to `contents` (the
+ * project-level `android/build.gradle` source), unless already present.
+ * Pure string transform, kept separate from the Expo mod plumbing so it can
+ * be unit tested directly.
+ * @throws {Error} If `language` isn't Groovy (`.kts` is not supported by this
+ * plugin, matching the library's own native config).
+ */
+const insertAndroidConfig = (contents, mlkitConfig, { language }) => {
+  if (language !== 'groovy') {
+    throw new Error(
+      'react-native-vision-camera-mlkit config plugin only supports Groovy android/build.gradle files, not Kotlin DSL (.kts).'
+    );
+  }
+
+  if (contents.includes(MARKER)) return contents;
+
+  return `${toGroovyBlock(mlkitConfig)}\n${contents}`;
+};
+
+/**
+ * Applies {@link insertAndroidConfig} to the project-level
+ * `android/build.gradle`, mirroring what `getMLKitConfig()` in the library's
+ * own `android/build.gradle` reads via `rootProject.ext`.
+ */
+const withVisionCameraMLKitAndroid = (config, mlkitConfig) =>
+  withProjectBuildGradle(config, (modConfig) => {
+    modConfig.modResults.contents = insertAndroidConfig(
+      modConfig.modResults.contents,
+      mlkitConfig,
+      { language: modConfig.modResults.language }
+    );
+    return modConfig;
+  });
+
+module.exports = { withVisionCameraMLKitAndroid, insertAndroidConfig };

--- a/plugin/withIOS.js
+++ b/plugin/withIOS.js
@@ -1,0 +1,60 @@
+const { withPodfile } = require('@expo/config-plugins');
+const { ANDROID_ONLY_KEYS } = require('./mlkitConfig');
+
+const MARKER =
+  '# react-native-vision-camera-mlkit selective ML Kit dependencies';
+
+/**
+ * Renders the iOS subset of `mlkitConfig` (Android-only keys dropped) as the
+ * Ruby hash consumers are otherwise told to hand-write before `target` in
+ * `ios/Podfile` (see README "ML Kit Models Installation (Selective)").
+ */
+const toRubyBlock = (mlkitConfig) => {
+  const entries = Object.entries(mlkitConfig)
+    .filter(([key]) => !ANDROID_ONLY_KEYS.has(key))
+    .map(([key, value]) => `  '${key}' => ${value},`)
+    .join('\n');
+
+  return `${MARKER}\n$VisionCameraMLKit = {\n${entries}\n}\n`;
+};
+
+/**
+ * Inserts the selective ML Kit dependency hash into `contents` (the
+ * `ios/Podfile` source) before the first `target` block, unless already
+ * present. Pure string transform, kept separate from the Expo mod plumbing
+ * so it can be unit tested directly.
+ * @throws {Error} If no `target` block is found to insert before.
+ */
+const insertIOSConfig = (contents, mlkitConfig) => {
+  if (contents.includes(MARKER)) return contents;
+
+  const targetIndex = contents.search(/^target\s/m);
+  if (targetIndex === -1) {
+    throw new Error(
+      'react-native-vision-camera-mlkit config plugin: could not find a `target` block in ios/Podfile to insert the ML Kit configuration before.'
+    );
+  }
+
+  return (
+    contents.slice(0, targetIndex) +
+    toRubyBlock(mlkitConfig) +
+    '\n' +
+    contents.slice(targetIndex)
+  );
+};
+
+/**
+ * Applies {@link insertIOSConfig} to `ios/Podfile`, mirroring what
+ * `VisionCameraMLKit.podspec` reads via the global `$VisionCameraMLKit`
+ * variable.
+ */
+const withVisionCameraMLKitIOS = (config, mlkitConfig) =>
+  withPodfile(config, (modConfig) => {
+    modConfig.modResults.contents = insertIOSConfig(
+      modConfig.modResults.contents,
+      mlkitConfig
+    );
+    return modConfig;
+  });
+
+module.exports = { withVisionCameraMLKitIOS, insertIOSConfig };

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,7 +32,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.29.0, @babel/code-frame@npm:^7.29.7":
+"@babel/code-frame@npm:^7.20.0, @babel/code-frame@npm:^7.29.0, @babel/code-frame@npm:^7.29.7":
   version: 7.29.7
   resolution: "@babel/code-frame@npm:7.29.7"
   dependencies:
@@ -2200,6 +2200,78 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/config-plugins@npm:57.0.6":
+  version: 57.0.6
+  resolution: "@expo/config-plugins@npm:57.0.6"
+  dependencies:
+    "@expo/config-types": "npm:^57.0.2"
+    "@expo/json-file": "npm:~11.0.1"
+    "@expo/plist": "npm:^0.8.1"
+    "@expo/require-utils": "npm:^57.0.4"
+    "@expo/sdk-runtime-versions": "npm:^1.0.0"
+    chalk: "npm:^4.1.2"
+    debug: "npm:^4.3.5"
+    getenv: "npm:^2.0.0"
+    glob: "npm:^13.0.0"
+    semver: "npm:^7.5.4"
+    slugify: "npm:^1.6.6"
+    xcode: "npm:^3.0.1"
+    xml2js: "npm:0.6.0"
+  checksum: 10c0/98ff17edf2bf90d9fa56dde28d0d13b3c11e4767dd0e21c4cf5187990526eb21949718a9dcc5f062a8903ab56c9382ccea75d871d4a9f72f1ab1a91e001a1826
+  languageName: node
+  linkType: hard
+
+"@expo/config-types@npm:^57.0.2":
+  version: 57.0.2
+  resolution: "@expo/config-types@npm:57.0.2"
+  checksum: 10c0/3e3a8abcab03791dfccc758bde5ce85f0fa4b14c22df072e6cc72c670945fc65433239bf2ce39f86bbda422b338d19323612d61eabb2442f988713214837a6dc
+  languageName: node
+  linkType: hard
+
+"@expo/json-file@npm:~11.0.1":
+  version: 11.0.1
+  resolution: "@expo/json-file@npm:11.0.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.20.0"
+    json5: "npm:^2.2.3"
+  checksum: 10c0/b93e8bf0654c7d417bf00a418932a3f676bc24bed75ff63a8c683229e2d1f3b7a48206fc3af7db307ed93a776adab51cb62ebb6a0ed77f86067c7ae85cc2f74d
+  languageName: node
+  linkType: hard
+
+"@expo/plist@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@expo/plist@npm:0.8.1"
+  dependencies:
+    "@xmldom/xmldom": "npm:^0.8.8"
+    base64-js: "npm:^1.5.1"
+    xmlbuilder: "npm:^15.1.1"
+  checksum: 10c0/45f130f3d5155d46dc415ab61b97449d5cc7bf47e41ed37965f12e50cc9728aa7c4da83fc958a8d7113e31e4342baebc1b2517de7e20186f3e64d53be378a9ce
+  languageName: node
+  linkType: hard
+
+"@expo/require-utils@npm:^57.0.4":
+  version: 57.0.4
+  resolution: "@expo/require-utils@npm:57.0.4"
+  dependencies:
+    "@babel/code-frame": "npm:^7.20.0"
+    "@babel/core": "npm:^7.25.2"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.24.8"
+  peerDependencies:
+    typescript: ^5.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/63ebc03ff9930af4c1680365b524ebe8aedab430273ad39a64c9afd5842e26fbfd7e38f10d5d2d2c6fc3849065ad1c9288a555596a1fd6fddb97c12e6844694f
+  languageName: node
+  linkType: hard
+
+"@expo/sdk-runtime-versions@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@expo/sdk-runtime-versions@npm:1.0.0"
+  checksum: 10c0/f80ae78a294daf396f3eff2eb412948ced5501395a6d3b88058866da9c5135dbacbb2804f8d062222e7452159a61eebefd2f548a2939f539f0f0efe8145588a2
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -4037,6 +4109,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 10c0/38a9c9b95450d7fccebc61371c8e0b90ceaae992886484108333d29ccbd2640e3555b6af012f15ce1beb5067aeb40486659b6183fad38af179e82d28028bfc5d
+  languageName: node
+  linkType: hard
+
 "JSONStream@npm:^1.3.5":
   version: 1.3.5
   resolution: "JSONStream@npm:1.3.5"
@@ -4631,6 +4717,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"big-integer@npm:1.6.x":
+  version: 1.6.52
+  resolution: "big-integer@npm:1.6.52"
+  checksum: 10c0/9604224b4c2ab3c43c075d92da15863077a9f59e5d4205f4e7e76acd0cd47e8d469ec5e5dba8d9b32aa233951893b29329ca56ac80c20ce094b4a647a66abae0
+  languageName: node
+  linkType: hard
+
 "bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -4666,6 +4759,24 @@ __metadata:
   version: 1.0.0
   resolution: "boolbase@npm:1.0.0"
   checksum: 10c0/e4b53deb4f2b85c52be0e21a273f2045c7b6a6ea002b0e139c744cb6f95e9ec044439a52883b0d74dedd1ff3da55ed140cfdddfed7fb0cccbed373de5dce1bcf
+  languageName: node
+  linkType: hard
+
+"bplist-creator@npm:0.1.1":
+  version: 0.1.1
+  resolution: "bplist-creator@npm:0.1.1"
+  dependencies:
+    stream-buffers: "npm:2.2.x"
+  checksum: 10c0/427ec37263ce0e8c68a83f595fc9889a9cbf2e6fda2de18e1f8ef7f0c6ce68c0cdbb7c9c1f3bb3f2d217407af8cffbdf254bf0f71c99f2186175d07752f08a47
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:0.3.2":
+  version: 0.3.2
+  resolution: "bplist-parser@npm:0.3.2"
+  dependencies:
+    big-integer: "npm:1.6.x"
+  checksum: 10c0/4dc307c11d2511a01255e87e370d4ab6f1962b35fdc27605fd4ce9a557a259c2dc9f87822617ddb1f7aa062a71e30ef20d6103329ac7ce235628f637fb0ed763
   languageName: node
   linkType: hard
 
@@ -4867,7 +4978,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -5566,7 +5677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -7047,6 +7158,13 @@ __metadata:
     data-uri-to-buffer: "npm:^6.0.2"
     debug: "npm:^4.3.4"
   checksum: 10c0/c7ff5d5d55de53d23ecce7c5108cc3ed0db1174db43c9aa15506d640283d36ee0956fd8ba1fc50b06a718466cc85794ae9d8860193f91318afe846e3e7010f3a
+  languageName: node
+  linkType: hard
+
+"getenv@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "getenv@npm:2.0.0"
+  checksum: 10c0/397ff641dd70cd78e414430258651e9a2228d3c5553a8cf15ae7840f75d3f10dfcb83f668f84829e84ea665b0fce2f08a9eddda3c9dcd7faa2d3da1c182c1854
   languageName: node
   linkType: hard
 
@@ -10549,6 +10667,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plist@npm:^3.0.5":
+  version: 3.1.1
+  resolution: "plist@npm:3.1.1"
+  dependencies:
+    "@xmldom/xmldom": "npm:^0.9.10"
+    base64-js: "npm:^1.5.1"
+    xmlbuilder: "npm:^15.1.1"
+  checksum: 10c0/af681277c2e541c6aab0ddee57f59459c43beeea1ee7aa2d4218aa39595fb41c068e2d2be3e4abb17e3252eaf2c1b806ecfb1d402fa5a3f4a6e1a7a32c880c9a
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -11026,6 +11155,7 @@ __metadata:
     "@eslint/compat": "npm:^1.3.2"
     "@eslint/eslintrc": "npm:^3.3.1"
     "@eslint/js": "npm:^9.35.0"
+    "@expo/config-plugins": "npm:57.0.6"
     "@react-native-community/cli": "npm:20.1.0"
     "@react-native/babel-preset": "npm:0.86.0"
     "@react-native/eslint-config": "npm:^0.86.0"
@@ -11051,10 +11181,14 @@ __metadata:
     turbo: "npm:^2.5.6"
     typescript: "npm:^5.9.2"
   peerDependencies:
+    "@expo/config-plugins": ^57.0.0
     react: "*"
     react-native: "*"
     react-native-nitro-modules: "*"
     react-native-vision-camera: ">=5"
+  peerDependenciesMeta:
+    "@expo/config-plugins":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -11544,6 +11678,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:>=0.6.0":
+  version: 1.6.1
+  resolution: "sax@npm:1.6.1"
+  checksum: 10c0/c91a71043d60da50fdf1e2cee936fc7ad4c9376afb8d1022aef5655f279433640859ec06b3b49abfcbe578fc7da2828cc1661e45aaedf835f5393496193437fa
+  languageName: node
+  linkType: hard
+
 "scheduler@npm:0.27.0":
   version: 0.27.0
   resolution: "scheduler@npm:0.27.0"
@@ -11761,6 +11902,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-plist@npm:^1.1.0":
+  version: 1.4.0
+  resolution: "simple-plist@npm:1.4.0"
+  dependencies:
+    bplist-creator: "npm:0.1.1"
+    bplist-parser: "npm:0.3.2"
+    plist: "npm:^3.0.5"
+  checksum: 10c0/226c283492d8518d715e4133d94bdbd15c0619561bcde583b4807b36cde106c0078c615b9b4e25c0e8758a4ae4e79ed5dd76e57cd528d8b7001ecab5ad35e343
+  languageName: node
+  linkType: hard
+
 "simple-swizzle@npm:^0.2.2":
   version: 0.2.4
   resolution: "simple-swizzle@npm:0.2.4"
@@ -11799,6 +11951,13 @@ __metadata:
     astral-regex: "npm:^1.0.0"
     is-fullwidth-code-point: "npm:^2.0.0"
   checksum: 10c0/c317b21ec9e3d3968f3d5b548cbfc2eae331f58a03f1352621020799cbe695b3611ee972726f8f32d4ca530065a5ec9c74c97fde711c1f41b4a1585876b2c191
+  languageName: node
+  linkType: hard
+
+"slugify@npm:^1.6.6":
+  version: 1.6.9
+  resolution: "slugify@npm:1.6.9"
+  checksum: 10c0/8473c566ae00c5db26bfbf6182a4a9478ab3c912a9c926e1fdb410736a77228bfca4fdc5c755b46fafa7d2d9900de482fd7a9bd5e5c91128c4743c2c072d88da
   languageName: node
   linkType: hard
 
@@ -11981,6 +12140,13 @@ __metadata:
     es-errors: "npm:^1.3.0"
     internal-slot: "npm:^1.1.0"
   checksum: 10c0/de4e45706bb4c0354a4b1122a2b8cc45a639e86206807ce0baf390ee9218d3ef181923fa4d2b67443367c491aa255c5fbaa64bb74648e3c5b48299928af86c09
+  languageName: node
+  linkType: hard
+
+"stream-buffers@npm:2.2.x":
+  version: 2.2.0
+  resolution: "stream-buffers@npm:2.2.0"
+  checksum: 10c0/14a351f0a066eaa08c8c64a74f4aedd87dd7a8e59d4be224703da33dca3eb370828ee6c0ae3fff59a9c743e8098728fc95c5f052ae7741672a31e6b1430ba50a
   languageName: node
   linkType: hard
 
@@ -12760,6 +12926,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "uuid@npm:7.0.3"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 10c0/2eee5723b0fcce8256f5bfd3112af6c453b5471db00af9c3533e3d5a6e57de83513f9a145a570890457bd7abf2c2aa05797291d950ac666e5a074895dc63168b
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -13045,6 +13220,40 @@ __metadata:
   dependencies:
     is-wsl: "npm:^3.1.0"
   checksum: 10c0/44318f3585eb97be994fc21a20ddab2649feaf1fbe893f1f866d936eea3d5f8c743bec6dc02e49fbdd3c0e69e9b36f449d90a0b165a4f47dd089747af4cf2377
+  languageName: node
+  linkType: hard
+
+"xcode@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "xcode@npm:3.0.1"
+  dependencies:
+    simple-plist: "npm:^1.1.0"
+    uuid: "npm:^7.0.3"
+  checksum: 10c0/51bf35cee52909aeb18f868ecf9828f93b8042fadf968159320f9f11e757a52e43f6563a53b586986cfe5a34d576f3300c4c0cf1e14300084344ae206eaa53c3
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:0.6.0":
+  version: 0.6.0
+  resolution: "xml2js@npm:0.6.0"
+  dependencies:
+    sax: "npm:>=0.6.0"
+    xmlbuilder: "npm:~11.0.0"
+  checksum: 10c0/db1ad659210eda4b77929aa692271308ec7e04830112161b8c707f3bcc7138947409c8461ae5c8bcb36b378d62594a8d1cb78770ff5c3dc46a68c67a0838b486
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:^15.1.1":
+  version: 15.1.1
+  resolution: "xmlbuilder@npm:15.1.1"
+  checksum: 10c0/665266a8916498ff8d82b3d46d3993913477a254b98149ff7cff060d9b7cc0db7cf5a3dae99aed92355254a808c0e2e3ec74ad1b04aa1061bdb8dfbea26c18b8
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 10c0/74b979f89a0a129926bc786b913459bdbcefa809afaa551c5ab83f89b1915bdaea14c11c759284bb9b931e3b53004dbc2181e21d3ca9553eeb0b2a7b4e40c35b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Delivers Phase 4 of the roadmap: an `app.plugin.js` so Expo prebuild users (`expo prebuild`, EAS Build, custom dev client) don't have to hand-edit `android/build.gradle`/`ios/Podfile` to selectively enable ML Kit models — mirrors the existing manual instructions in the README exactly, same flag names, same defaults for anything omitted.

- **`plugin/mlkitConfig.js`** — the 16 documented feature keys, fail-fast validation (throws on unknown keys instead of silently ignoring typos, matching this repo's `validateRegionOfInterest.ts` precedent).
- **`plugin/withAndroid.js`** — prepends the `ext["react-native-vision-camera-mlkit"]` Groovy block to the project-level `android/build.gradle` via `withProjectBuildGradle`; throws on Kotlin DSL (`.kts`), which the native config doesn't support either.
- **`plugin/withIOS.js`** — inserts the `$VisionCameraMLKit` Ruby hash before the first `target` block in `ios/Podfile` via `withPodfile`, dropping the three Android-only keys (`faceMeshDetection`, `subjectSegmentation`, `documentScanner`) that don't exist in the podspec's config.
- Both mods are idempotent (marker-checked, not relying solely on `createRunOncePlugin`'s own dedup, since a real `expo prebuild` invocation builds a fresh config object each run).

`@expo/config-plugins` added as an **optional** peer dependency (`peerDependenciesMeta`) — Expo projects already have it transitively via `expo` itself; non-Expo consumers never need it, matching this session's earlier peer-dependency cleanup (#15).

README gets a new "Expo (config plugin)" subsection under ML Kit Models Installation; the old blanket "follow the Vision Camera guide" note now clarifies that's for Vision Camera's own Expo setup, not this plugin.

## Test plan

- [x] `yarn lint` / `yarn typecheck` / `yarn test` all green (11 new plugin unit tests covering insertion, idempotency, Android-only key filtering, and the Kotlin-DSL/missing-target error paths)
- [x] `yarn prepare` (bob build) succeeds
- [x] **End-to-end smoke test** against real files: built a temp fixture project with a real `android/build.gradle` + `ios/Podfile`, ran the plugin through `@expo/config-plugins`' actual `compileModsAsync` pipeline (not just the unit tests), confirmed the written files are correct, then ran the full pipeline a second time against the same files to confirm idempotency holds end-to-end, not just in the pure-function tests
- [x] Not yet tested: an actual `expo prebuild` run in a real Expo app (no Expo app available in this environment) — the smoke test above exercises the same underlying mod-compiler API Expo itself calls, but a real prebuild run would be good final confirmation before considering this fully battle-tested