### PR TITLE
fix(ios): keep text recognition switch exhaustive under selective install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- iOS: text recognition failed to build whenever any language model was
+  disabled through the selective ML Kit install. Each `case` of the
+  `switch` over `DomainTextRecognitionLanguage` was wrapped in its own
+  `#if MLKIT_TEXT_RECOGNITION*` flag, so any partial selection compiled a
+  case out while the enum still declared all five, leaving the switch
+  non-exhaustive (`switch must be exhaustive`). Only all-enabled or
+  all-disabled builds compiled, which defeated the point of selective
+  install. The guards now live inside each case body, keeping the switch
+  exhaustive under every flag combination. Requesting a language whose
+  model was excluded throws a descriptive error naming the configuration
+  key to enable, matching the exception Android already raises, rather
+  than crashing. (#22)
+
 ## [2.0.0] - 2026-08-02
 
 Major, breaking release. Migrates off the legacy TurboModule bridge onto

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2934,7 +2934,7 @@ SPEC CHECKSUMS:
   RNSVG: ffe18ba0e8fbad864bf22d6f0060a4ee88ec9bf3
   RNWorklets: 82a5f27dcf3bb69267ec6ce662a756a4d3f61522
   VisionCamera: 4e3e123f4d14c7d3934748c84fe6ddfa5046c5ee
-  VisionCameraMLKit: 08f7f64b2794cde438ca7ab82a4d904d52d44dd3
+  VisionCameraMLKit: d09e2ba43e985a98e73b7b19d3b9caa2a56c0142
   VisionCameraWorklets: 0d8b34820c6aa351fbba9fab3d8ee8e8d98e1990
   Yoga: 94172d87dd5d83fc929bf1ee53121b5d4490b5f2
 

--- a/ios/Bridge/Hybrid/HybridTextRecognizer.swift
+++ b/ios/Bridge/Hybrid/HybridTextRecognizer.swift
@@ -15,16 +15,16 @@ final class HybridTextRecognizer: HybridTextRecognizerSpec {
     private let staticRecognitionService: MLKitTextRecognitionService
   #endif
 
-  init(options: TextRecognizerOptions) {
+  init(options: TextRecognizerOptions) throws {
     self.options = options
     #if MLKIT_TEXT_RECOGNITION_ANY
       let resolvedTextOptions = options.toDomainTextRecognitionOptions()
       self.textOptions = resolvedTextOptions
       self.imageOptions = options.toImagePreprocessingOptions()
-      self.recognitionService = TextRecognitionServiceFactory.create(
+      self.recognitionService = try TextRecognitionServiceFactory.create(
         language: resolvedTextOptions.language
       )
-      self.staticRecognitionService = TextRecognitionServiceFactory.create(
+      self.staticRecognitionService = try TextRecognitionServiceFactory.create(
         language: resolvedTextOptions.language
       )
     #endif

--- a/ios/Bridge/Hybrid/HybridVisionCameraMLKit.swift
+++ b/ios/Bridge/Hybrid/HybridVisionCameraMLKit.swift
@@ -62,7 +62,7 @@ final class HybridVisionCameraMLKit: HybridVisionCameraMLKitSpec {
       throw RuntimeError.error(withMessage: "TextRecognition is not enabled in the native ML Kit configuration.")
     }
 
-    return HybridTextRecognizer(options: options)
+    return try HybridTextRecognizer(options: options)
   }
 
   func createBarcodeScanner(options: BarcodeScannerOptions) throws -> any HybridBarcodeScannerSpec {

--- a/ios/Infrastructure/MLKit/Factories/TextRecognitionServiceFactory.swift
+++ b/ios/Infrastructure/MLKit/Factories/TextRecognitionServiceFactory.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NitroModules
 
 #if MLKIT_TEXT_RECOGNITION_ANY
   import MLKitTextRecognition
@@ -23,41 +24,81 @@ import Foundation
 #if MLKIT_TEXT_RECOGNITION_ANY
   class TextRecognitionServiceFactory {
 
-    static func createTextRecognizer(language: DomainTextRecognitionLanguage)
+    /// Recognizer options for `language`, or `nil` when that language model was
+    /// excluded from this build by the selective ML Kit configuration.
+    ///
+    /// The `#if` guards live inside each `case` body rather than around the
+    /// `case` labels themselves: that keeps the switch exhaustive under every
+    /// combination of model flags, so adding a language to
+    /// `DomainTextRecognitionLanguage` still fails the build until it is
+    /// handled here.
+    private static func makeOptions(for language: DomainTextRecognitionLanguage)
+      -> CommonTextRecognizerOptions?
+    {
+      switch language {
+      case .latin:
+        #if MLKIT_TEXT_RECOGNITION
+          return MLKitTextRecognition.TextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .chinese:
+        #if MLKIT_TEXT_RECOGNITION_CHINESE
+          return ChineseTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .devanagari:
+        #if MLKIT_TEXT_RECOGNITION_DEVANAGARI
+          return DevanagariTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .japanese:
+        #if MLKIT_TEXT_RECOGNITION_JAPANESE
+          return JapaneseTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .korean:
+        #if MLKIT_TEXT_RECOGNITION_KOREAN
+          return KoreanTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      }
+    }
+
+    /// Configuration key that enables `language`'s model, as accepted by the
+    /// `$VisionCameraMLKit` Podfile hash and the Expo config plugin.
+    private static func configurationKey(for language: DomainTextRecognitionLanguage) -> String {
+      switch language {
+      case .latin: return "textRecognition"
+      case .chinese: return "textRecognitionChinese"
+      case .devanagari: return "textRecognitionDevanagari"
+      case .japanese: return "textRecognitionJapanese"
+      case .korean: return "textRecognitionKorean"
+      }
+    }
+
+    static func createTextRecognizer(language: DomainTextRecognitionLanguage) throws
       -> TextRecognizer
     {
-      let options: CommonTextRecognizerOptions
-
-      switch language {
-      #if MLKIT_TEXT_RECOGNITION
-        case .latin:
-          options = MLKitTextRecognition.TextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_CHINESE
-        case .chinese:
-          options = ChineseTextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_DEVANAGARI
-        case .devanagari:
-          options = DevanagariTextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_JAPANESE
-        case .japanese:
-          options = JapaneseTextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_KOREAN
-        case .korean:
-          options = KoreanTextRecognizerOptions()
-      #endif
+      guard let options = makeOptions(for: language) else {
+        throw RuntimeError.error(
+          withMessage:
+            "Text recognition for \(language.rawValue) is not enabled in this build. "
+            + "Set \(configurationKey(for: language)) to true in your ML Kit configuration."
+        )
       }
 
       return TextRecognizer.textRecognizer(options: options)
     }
 
-    static func create(language: DomainTextRecognitionLanguage = .latin)
+    static func create(language: DomainTextRecognitionLanguage = .latin) throws
       -> MLKitTextRecognitionService
     {
-      let textRecognizer = createTextRecognizer(language: language)
+      let textRecognizer = try createTextRecognizer(language: language)
       return MLKitTextRecognitionService(textRecognizer: textRecognizer)
     }
   }


### PR DESCRIPTION
Related to #22 (intentionally **not** using a closing keyword — see Notes).

## Summary

Text recognition failed to build on iOS as soon as any single language model
was disabled through the selective ML Kit install, which is the entire point
of that feature. Reported against 2.0.0 with an Expo prebuild config, but the
bare Podfile path produces identical flags and fails the same way.

## Root cause

`DomainTextRecognitionLanguage` declares all five cases unconditionally, while
every `case` in `TextRecognitionServiceFactory.createTextRecognizer` was
individually wrapped in its own `#if MLKIT_TEXT_RECOGNITION*` flag with no
`default:`. Disabling a language compiled its `case` out while the enum still
declared it, so the switch was no longer exhaustive:

```
TextRecognitionServiceFactory.swift:31:7: error: switch must be exhaustive
```

Only all-five-enabled compiled, or all-five-disabled (where
`MLKIT_TEXT_RECOGNITION_ANY` goes unset and the whole file drops out). Every
partial selection — the feature's actual purpose — was broken.

This shipped because no iOS CI job compiles a partial config: `build-ios.yml`
builds the example app, and `example/ios/Podfile` pins all five to `true`.

## The fix

The `#if` guards move *inside* each `case` body, via a `makeOptions(for:)`
helper that returns `nil` for models excluded from the build. The switch lists
all five cases unconditionally, so it stays exhaustive under every flag
combination.

A language whose model was excluded now throws a descriptive error naming the
configuration key to enable, matching the `IllegalStateException` Android
already raises from its own factory. `createTextRecognizer`/`create` become
throwing, so `HybridTextRecognizer.init` throws and its single call site in
`HybridVisionCameraMLKit` uses `try`.

## Alternatives considered and rejected

**`default:` + `fatalError`** (suggested in the issue) compiles, and Swift
emits no unreachable-default warning when all five are enabled. Rejected
because it crashes the process where Android throws a catchable exception for
the same misconfiguration, and because it permanently disables exhaustiveness
checking — verified by simulating a sixth enum case: the `default:` version
compiles silently, this version fails the build.

**Gating the enum cases** (the issue's alternative) does not work.
`TextRecognitionLanguage+toDomain.swift` maps the Nitro-generated
`TextRecognitionLanguage` — C++-backed, all five cases, marked DO NOT MODIFY —
so removing domain cases relocates the same error into the mapper. It also
would not surface at the JS/TS boundary, since that union is generated from the
Nitro spec and is independent of build flags.

## Validation

Real `pod install` + `xcodebuild` per config, reading the emitted
`SWIFT_ACTIVE_COMPILATION_CONDITIONS` back from the generated xcconfig rather
than trusting the Podfile (the podspec merges over all-`true` defaults and does
not validate keys, so a typo would silently produce an all-enabled build).

| Config | Branch | Scope | Result |
| --- | --- | --- | --- |
| latin only | `develop` | pod scheme | **FAIL** — `switch must be exhaustive` at 31:7 |
| latin only | this branch | pod scheme | PASS |
| chinese only, latin off | this branch | pod scheme | PASS |
| all five | this branch | pod scheme | PASS |
| latin only | this branch | full app | PASS (links) |

Rows 1 and 2 use an identical Podfile and identical emitted flags; the branch
is the only variable. Row 1 reproduces the reporter's error at the same file,
line, and column. Row 3 also confirms the podspec still pulls base
`GoogleMLKit/TextRecognition` for shared types when `textRecognition => false`.

Not covered: the runtime throw reaching JS. Low risk rather than unknown —
`HybridVisionCameraMLKit.createTextRecognizer` already threw a `RuntimeError`
for the disabled-feature case before this change, so that propagation path is
pre-existing and exercised.

## Notes

- **The issue must stay open.** No closing keyword here, so merging to
  `develop` changes nothing. Note the fix commit body does contain one, which
  will auto-close #22 when it reaches `main` — to be amended before release.
- CI left unchanged by maintainer decision; the five ML Kit scripts are the
  complete set, so the enum will not grow.
- CHANGELOG entry added under `[Unreleased]`; version header stamped at release.
