### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1-rc.0] - 2026-08-20
+
 ### Fixed
 
 - iOS: text recognition failed to build whenever any language model was
@@ -76,7 +78,8 @@ Complete project rewrite.
 
 Initial release.
 
-[Unreleased]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v2.0.1-rc.0...HEAD
+[2.0.1-rc.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v2.0.0...v2.0.1-rc.0
 [2.0.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- iOS: text recognition failed to build whenever any language model was
+  disabled through the selective ML Kit install. Each `case` of the
+  `switch` over `DomainTextRecognitionLanguage` was wrapped in its own
+  `#if MLKIT_TEXT_RECOGNITION*` flag, so any partial selection compiled a
+  case out while the enum still declared all five, leaving the switch
+  non-exhaustive (`switch must be exhaustive`). Only all-enabled or
+  all-disabled builds compiled, which defeated the point of selective
+  install. The guards now live inside each case body, keeping the switch
+  exhaustive under every flag combination. Requesting a language whose
+  model was excluded throws a descriptive error naming the configuration
+  key to enable, matching the exception Android already raises, rather
+  than crashing. (#22)
+
 ## [2.0.0] - 2026-08-02
 
 Major, breaking release. Migrates off the legacy TurboModule bridge onto

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1-rc.0] - 2026-08-20
+## [2.0.1] - 2026-08-20
 
 ### Fixed
 
@@ -78,8 +78,8 @@ Complete project rewrite.
 
 Initial release.
 
-[Unreleased]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v2.0.1-rc.0...HEAD
-[2.0.1-rc.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v2.0.0...v2.0.1-rc.0
+[Unreleased]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/pedrol2b/react-native-vision-camera-mlkit/releases/tag/v0.1.0

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2469,7 +2469,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - VisionCameraMLKit (2.0.0):
+  - VisionCameraMLKit (2.0.1-rc.0):
     - GoogleMLKit/BarcodeScanning
     - GoogleMLKit/TextRecognition
     - GoogleMLKit/TextRecognitionChinese
@@ -2934,7 +2934,7 @@ SPEC CHECKSUMS:
   RNSVG: ffe18ba0e8fbad864bf22d6f0060a4ee88ec9bf3
   RNWorklets: 82a5f27dcf3bb69267ec6ce662a756a4d3f61522
   VisionCamera: 4e3e123f4d14c7d3934748c84fe6ddfa5046c5ee
-  VisionCameraMLKit: d09e2ba43e985a98e73b7b19d3b9caa2a56c0142
+  VisionCameraMLKit: b370f856d77eebe35216d3f7e5a29a002ce1946d
   VisionCameraWorklets: 0d8b34820c6aa351fbba9fab3d8ee8e8d98e1990
   Yoga: 94172d87dd5d83fc929bf1ee53121b5d4490b5f2
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2469,7 +2469,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - VisionCameraMLKit (2.0.1-rc.0):
+  - VisionCameraMLKit (2.0.1):
     - GoogleMLKit/BarcodeScanning
     - GoogleMLKit/TextRecognition
     - GoogleMLKit/TextRecognitionChinese
@@ -2934,7 +2934,7 @@ SPEC CHECKSUMS:
   RNSVG: ffe18ba0e8fbad864bf22d6f0060a4ee88ec9bf3
   RNWorklets: 82a5f27dcf3bb69267ec6ce662a756a4d3f61522
   VisionCamera: 4e3e123f4d14c7d3934748c84fe6ddfa5046c5ee
-  VisionCameraMLKit: b370f856d77eebe35216d3f7e5a29a002ce1946d
+  VisionCameraMLKit: 071ddfbd002020f15562ef91883174fe39b1d0d4
   VisionCameraWorklets: 0d8b34820c6aa351fbba9fab3d8ee8e8d98e1990
   Yoga: 94172d87dd5d83fc929bf1ee53121b5d4490b5f2
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2934,7 +2934,7 @@ SPEC CHECKSUMS:
   RNSVG: ffe18ba0e8fbad864bf22d6f0060a4ee88ec9bf3
   RNWorklets: 82a5f27dcf3bb69267ec6ce662a756a4d3f61522
   VisionCamera: 4e3e123f4d14c7d3934748c84fe6ddfa5046c5ee
-  VisionCameraMLKit: 08f7f64b2794cde438ca7ab82a4d904d52d44dd3
+  VisionCameraMLKit: d09e2ba43e985a98e73b7b19d3b9caa2a56c0142
   VisionCameraWorklets: 0d8b34820c6aa351fbba9fab3d8ee8e8d98e1990
   Yoga: 94172d87dd5d83fc929bf1ee53121b5d4490b5f2
 

--- a/ios/Bridge/Hybrid/HybridTextRecognizer.swift
+++ b/ios/Bridge/Hybrid/HybridTextRecognizer.swift
@@ -15,16 +15,16 @@ final class HybridTextRecognizer: HybridTextRecognizerSpec {
     private let staticRecognitionService: MLKitTextRecognitionService
   #endif
 
-  init(options: TextRecognizerOptions) {
+  init(options: TextRecognizerOptions) throws {
     self.options = options
     #if MLKIT_TEXT_RECOGNITION_ANY
       let resolvedTextOptions = options.toDomainTextRecognitionOptions()
       self.textOptions = resolvedTextOptions
       self.imageOptions = options.toImagePreprocessingOptions()
-      self.recognitionService = TextRecognitionServiceFactory.create(
+      self.recognitionService = try TextRecognitionServiceFactory.create(
         language: resolvedTextOptions.language
       )
-      self.staticRecognitionService = TextRecognitionServiceFactory.create(
+      self.staticRecognitionService = try TextRecognitionServiceFactory.create(
         language: resolvedTextOptions.language
       )
     #endif

--- a/ios/Bridge/Hybrid/HybridVisionCameraMLKit.swift
+++ b/ios/Bridge/Hybrid/HybridVisionCameraMLKit.swift
@@ -62,7 +62,7 @@ final class HybridVisionCameraMLKit: HybridVisionCameraMLKitSpec {
       throw RuntimeError.error(withMessage: "TextRecognition is not enabled in the native ML Kit configuration.")
     }
 
-    return HybridTextRecognizer(options: options)
+    return try HybridTextRecognizer(options: options)
   }
 
   func createBarcodeScanner(options: BarcodeScannerOptions) throws -> any HybridBarcodeScannerSpec {

--- a/ios/Infrastructure/MLKit/Factories/TextRecognitionServiceFactory.swift
+++ b/ios/Infrastructure/MLKit/Factories/TextRecognitionServiceFactory.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NitroModules
 
 #if MLKIT_TEXT_RECOGNITION_ANY
   import MLKitTextRecognition
@@ -23,41 +24,81 @@ import Foundation
 #if MLKIT_TEXT_RECOGNITION_ANY
   class TextRecognitionServiceFactory {
 
-    static func createTextRecognizer(language: DomainTextRecognitionLanguage)
+    /// Recognizer options for `language`, or `nil` when that language model was
+    /// excluded from this build by the selective ML Kit configuration.
+    ///
+    /// The `#if` guards live inside each `case` body rather than around the
+    /// `case` labels themselves: that keeps the switch exhaustive under every
+    /// combination of model flags, so adding a language to
+    /// `DomainTextRecognitionLanguage` still fails the build until it is
+    /// handled here.
+    private static func makeOptions(for language: DomainTextRecognitionLanguage)
+      -> CommonTextRecognizerOptions?
+    {
+      switch language {
+      case .latin:
+        #if MLKIT_TEXT_RECOGNITION
+          return MLKitTextRecognition.TextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .chinese:
+        #if MLKIT_TEXT_RECOGNITION_CHINESE
+          return ChineseTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .devanagari:
+        #if MLKIT_TEXT_RECOGNITION_DEVANAGARI
+          return DevanagariTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .japanese:
+        #if MLKIT_TEXT_RECOGNITION_JAPANESE
+          return JapaneseTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      case .korean:
+        #if MLKIT_TEXT_RECOGNITION_KOREAN
+          return KoreanTextRecognizerOptions()
+        #else
+          return nil
+        #endif
+      }
+    }
+
+    /// Configuration key that enables `language`'s model, as accepted by the
+    /// `$VisionCameraMLKit` Podfile hash and the Expo config plugin.
+    private static func configurationKey(for language: DomainTextRecognitionLanguage) -> String {
+      switch language {
+      case .latin: return "textRecognition"
+      case .chinese: return "textRecognitionChinese"
+      case .devanagari: return "textRecognitionDevanagari"
+      case .japanese: return "textRecognitionJapanese"
+      case .korean: return "textRecognitionKorean"
+      }
+    }
+
+    static func createTextRecognizer(language: DomainTextRecognitionLanguage) throws
       -> TextRecognizer
     {
-      let options: CommonTextRecognizerOptions
-
-      switch language {
-      #if MLKIT_TEXT_RECOGNITION
-        case .latin:
-          options = MLKitTextRecognition.TextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_CHINESE
-        case .chinese:
-          options = ChineseTextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_DEVANAGARI
-        case .devanagari:
-          options = DevanagariTextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_JAPANESE
-        case .japanese:
-          options = JapaneseTextRecognizerOptions()
-      #endif
-      #if MLKIT_TEXT_RECOGNITION_KOREAN
-        case .korean:
-          options = KoreanTextRecognizerOptions()
-      #endif
+      guard let options = makeOptions(for: language) else {
+        throw RuntimeError.error(
+          withMessage:
+            "Text recognition for \(language.rawValue) is not enabled in this build. "
+            + "Set \(configurationKey(for: language)) to true in your ML Kit configuration."
+        )
       }
 
       return TextRecognizer.textRecognizer(options: options)
     }
 
-    static func create(language: DomainTextRecognitionLanguage = .latin)
+    static func create(language: DomainTextRecognitionLanguage = .latin) throws
       -> MLKitTextRecognitionService
     {
-      let textRecognizer = createTextRecognizer(language: language)
+      let textRecognizer = try createTextRecognizer(language: language)
       return MLKitTextRecognitionService(textRecognizer: textRecognizer)
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-camera-mlkit",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.0",
   "description": "A React Native Vision Camera (v5, Nitro-based) plugin for Google ML Kit vision features. Ships text recognition (OCR) and barcode scanning today, each independently selectable to keep binary size down, for real-time frame processing and static images, with more ML Kit vision features (face detection, pose detection, and others) on the roadmap.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-vision-camera-mlkit",
-  "version": "2.0.1-rc.0",
+  "version": "2.0.1",
   "description": "A React Native Vision Camera (v5, Nitro-based) plugin for Google ML Kit vision features. Ships text recognition (OCR) and barcode scanning today, each independently selectable to keep binary size down, for real-time frame processing and static images, with more ML Kit vision features (face detection, pose detection, and others) on the roadmap.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
Release **2.0.1** — patch release promoting `2.0.1-rc.0` to `latest` after the
reporter of #22 confirmed the release candidate resolves the failure.

> Confirmed working with 2.0.1-rc.0.

## ⚠️ Merging this will auto-close #22

The fix commit (`2658145`) body contains `Fixes #22`. That keyword is inert on
`develop`, but lands on the default branch with this merge, so GitHub will
close the issue **at merge time** — before the tag, release, and npm publish
complete. Expected and accounted for; the closing comment goes up after the
publish lands.

## What ships

Only the iOS selective ML Kit install build fix. No other work is riding along
— `main` already has everything else.

Text recognition could not build on iOS whenever any language model was
disabled through the selective install, because each `case` of the switch over
`DomainTextRecognitionLanguage` was wrapped in its own `#if
MLKIT_TEXT_RECOGNITION*` flag while the enum declared all five
unconditionally, leaving the switch non-exhaustive. Every partial selection —
the feature's whole purpose — failed with `switch must be exhaustive`. The
guards now live inside each case body, so the switch stays exhaustive under
every flag combination, and an excluded language throws a descriptive error
naming the config key to enable, matching Android, instead of crashing.

Full detail in #23.

## Commits

| Commit | |
| --- | --- |
| `2658145` | fix(ios): keep text recognition switch exhaustive under selective install |
| `87c0417` | chore(ios): update Podfile.lock |
| `bb57f25` | docs: changelog entry |
| `79e3117` | Merge PR #23 |
| `6035984` | chore(release): 2.0.1-rc.0 |
| `3ddf864` | chore(release): 2.0.1 |

## Diff

6 files. `TextRecognitionServiceFactory.swift` is the fix;
`HybridTextRecognizer.swift` and `HybridVisionCameraMLKit.swift` propagate
`throws`; `package.json` and `example/ios/Podfile.lock` carry the version;
`CHANGELOG.md` gets the `[2.0.1]` section.

The CHANGELOG section was renamed from `[2.0.1-rc.0]` to `[2.0.1]` rather than
duplicated — shipped content is identical and the rc existed only to validate
against a real published artifact.

## Validation

Verified on the RC by the reporter on their EAS build, and locally with real
`pod install` + `xcodebuild` per configuration, reading the emitted
`SWIFT_ACTIVE_COMPILATION_CONDITIONS` back from the generated xcconfig:

| Config | Result |
| --- | --- |
| latin only, pre-fix | fails — `switch must be exhaustive` at 31:7 |
| latin only | builds |
| chinese only, latin disabled | builds |
| all five | builds |
| latin only, full app | builds and links |

The published `2.0.1-rc.0` tarball was also pulled back from the registry and
confirmed to contain the fixed sources.

## After merge

1. Tag `v2.0.1` on the merge commit
2. GitHub release (not prerelease) → workflow publishes to npm under `latest`
3. Verify `dist-tags.latest = 2.0.1`
4. Closing comment on #22
